### PR TITLE
Chore: Add current version to docs

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,10 +1,11 @@
+import { TitleWithVersion } from '../docs/utils';
 import theme from './theme';
 
 export const parameters = {
     options: {
         storySort: {
             method: 'alphabetical',
-            order: ['Playbook', 'Status', 'Icon Set', 'CSS Utilities']
+            order: [TitleWithVersion, 'Status', 'Icon Set', 'CSS Utilities']
         }
     },
     docs: {

--- a/docs/Playbook.stories.mdx
+++ b/docs/Playbook.stories.mdx
@@ -1,6 +1,7 @@
+import { TitleWithVersion } from './utils';
 import { Meta } from '@storybook/addon-docs/blocks';
 
-<Meta title="Playbook" />
+<Meta title={TitleWithVersion} />
 
 # FieldLevel Playbook
 

--- a/docs/Status.stories.mdx
+++ b/docs/Status.stories.mdx
@@ -1,12 +1,14 @@
 import { Meta } from '@storybook/addon-docs/blocks';
 
-import { InDevelopment, Released, Deprecated, Planned } from './utils';
+import { CurrentVersion, InDevelopment, Released, Deprecated, Planned } from './utils';
 
 <Meta title="Status" />
 
 # Component status
 
-The latest Playbook component status and availability. If you have a suggestion for a new component that is not listed you can [create an issue on GitHub](https://github.com/FieldLevel/FieldLevelPlaybook/issues/new)
+Latest release: <CurrentVersion />
+
+The latest Playbook component status and availability. Check the [release notes](https://github.com/FieldLevel/FieldLevelPlaybook/releases) for details about new releases.
 
 | Component                                               | Status                       | Notes                                                                                                                              |
 | ------------------------------------------------------- | ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/utils.tsx
+++ b/docs/utils.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import cx from 'classnames';
+import pkg from '../package.json';
 
 const colorStyles = {
     success: 'text-success bg-background-success',
@@ -13,6 +14,10 @@ const Badge = ({ type, children }) => {
     const style = cx('inline-block mt-2 px-2 py-0.5 rounded shadow', colorStyle);
     return <div className={style}>{children}</div>;
 };
+
+export const TitleWithVersion = `Playbook v${pkg.version}`;
+
+export const CurrentVersion = () => <Badge type="success">v{pkg.version}</Badge>;
 
 export const InDevelopment = () => <Badge type="warning">In Development</Badge>;
 


### PR DESCRIPTION
Adds the version number to the "Playbook" page title. Adds a "current version" badge on the Status page and a link to the GitHub release notes page.

Resolves #51 