### PR TITLE
Feature: Add auto-grow functionality for multiline TextInput

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,6 +6,8 @@ See [the versioning guidelines](VERSIONING.md) for how to format entries.
 
 ### Enhancements
 
+-   Add auto-grow functionality for multiline `TextInput` ([#70](https://github.com/FieldLevel/FieldLevelPlaybook/pull/70))
+
 ### Bug fixes
 
 ### Documentation

--- a/docs/Forms/TextInput.stories.mdx
+++ b/docs/Forms/TextInput.stories.mdx
@@ -75,10 +75,12 @@ A Text Input is an input field that users can type into. It has a range of optio
     <Story story={stories.MaxLength} />
 </Canvas>
 
-## Multi-line
+## Rows
+
+Use when anticipating longer values. Controlled by the minimum number of `rows` to display and will automatically expand to `maxRows`.
 
 <Canvas>
-    <Story story={stories.Multiline} />
+    <Story story={stories.Rows} />
 </Canvas>
 
 ## Input reference

--- a/docs/Forms/TextInput.stories.tsx
+++ b/docs/Forms/TextInput.stories.tsx
@@ -60,13 +60,13 @@ export const Type = () => (
 
 export const MaxLength = () => <TextInput label="Headline" name="headline" maxLength={20} />;
 
-export const Multiline = () => <TextInput label="Headline" name="headline" multiline />;
+export const Rows = () => <TextInput label="Headline" name="headline" rows={3} maxRows={5} />;
 
 export const Reference = () => {
     const inputRef = useRef<HTMLInputElement>(null);
 
     const focusInput = () => {
-        inputRef.current.focus();
+        inputRef.current?.focus();
     };
 
     return (

--- a/src/components/TextInput/TextInput.module.css
+++ b/src/components/TextInput/TextInput.module.css
@@ -6,7 +6,9 @@
 .TextInput textarea {
     @apply rounded-md shadow-sm border border-base py-2 px-3 w-full max-h-40;
     @apply outline-none focus:ring placeholder-text-muted;
+    line-height: 20px;
     min-height: 40px;
+    resize: none;
 }
 
 .disabled input,


### PR DESCRIPTION
Deprecates the `multiline` prop for the `TextInput` component in favor of  `rows` and `maxRows` in order to to add auto-grow functionality and have control over the visual height of the component. Setting the `rows` prop will switch the input to use a `<textarea>` instead of an `<input>` and an optional `maxRows` prop can control how large the component will expand visually before scrolling the content.

The `multiline` prop is marked as deprecated but will continue to function as if `rows={3}` was passed.

Also added #71 as a future enhancement idea based on feedback from @aChristmasMiracle 

Resolves #69 