### PR TITLE
Fix: Vertical alignment of TextInput in multiline mode

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,6 +10,8 @@ See [the versioning guidelines](VERSIONING.md) for how to format entries.
 
 ### Bug fixes
 
+-   Fix vertical alignment of `TextInput` in multiline mode ([#74](https://github.com/FieldLevel/FieldLevelPlaybook/pull/74))
+
 ### Documentation
 
 ### Development workflow

--- a/src/components/TextInput/TextInput.module.css
+++ b/src/components/TextInput/TextInput.module.css
@@ -4,11 +4,10 @@
 
 .TextInput input,
 .TextInput textarea {
-    @apply rounded-md shadow-sm border border-base py-2 px-3 w-full max-h-40;
+    @apply rounded-md shadow-sm border border-base py-2 px-3 w-full max-h-40 align-bottom resize-none;
     @apply outline-none focus:ring placeholder-text-muted;
     line-height: 20px;
     min-height: 40px;
-    resize: none;
 }
 
 .disabled input,


### PR DESCRIPTION
Setting vertical alignment on the `<textarea>` fixes the case of having phantom margin/padding in multiline mode for the `TextInput`.

![image](https://user-images.githubusercontent.com/932981/185521811-69feb34d-5e56-436e-87c3-8251ecf50eed.png)

Fixes #73 
