### PR TITLE
Fix: Make sure TextInput resizes properly when cleared or initialized

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -11,6 +11,7 @@ See [the versioning guidelines](VERSIONING.md) for how to format entries.
 ### Bug fixes
 
 -   Fix vertical alignment of `TextInput` in multiline mode ([#74](https://github.com/FieldLevel/FieldLevelPlaybook/pull/74))
+-   Make sure TextInput resizes properly when cleared or initialized ([#75]https://github.com/FieldLevel/FieldLevelPlaybook/pull/75)
 
 ### Documentation
 

--- a/docs/Forms/TextInput.stories.mdx
+++ b/docs/Forms/TextInput.stories.mdx
@@ -83,8 +83,10 @@ Use when anticipating longer values. Controlled by the minimum number of `rows` 
     <Story story={stories.Rows} />
 </Canvas>
 
-## Input reference
+## Focus
+
+You can set focus on the underlying HTML element by utilizing the `ref` prop.
 
 <Canvas>
-    <Story story={stories.Reference} />
+    <Story story={stories.Focus} />
 </Canvas>

--- a/docs/Forms/TextInput.stories.tsx
+++ b/docs/Forms/TextInput.stories.tsx
@@ -2,6 +2,7 @@
 import React, { useRef, useState } from 'react';
 
 import { TextInput, FormLayout, Button, Stack } from '../../src';
+import type { TextInputRef } from '../../src/components/TextInput';
 import { SearchMinor } from '../../src';
 
 export const Default = (args: any) => <TextInput {...args} label="Headline" name="headline" />;
@@ -62,8 +63,8 @@ export const MaxLength = () => <TextInput label="Headline" name="headline" maxLe
 
 export const Rows = () => <TextInput label="Headline" name="headline" rows={3} maxRows={5} />;
 
-export const Reference = () => {
-    const inputRef = useRef<HTMLInputElement>(null);
+export const Focus = () => {
+    const inputRef = useRef<TextInputRef>(null);
 
     const focusInput = () => {
         inputRef.current?.focus();


### PR DESCRIPTION
If the `TextInput` had the `rows` and `maxRows` props set and was either initialized with a value that would cause the input to grow or the user entered a value that caused the input to grow and then the value was cleared, the TextInput wasn't properly resizing back to the initial rows size until the next value change event.

We require the inner ref to fix this, so the method of forwarding the inner ref has changed to use `useImperativeHandle` and expose only the functionality that we'd like to expose on the inner element rather than forwarding the entire element ref. This is also good because it allows us to control what functionality we expose vs just having the entire inner element exposed by ref.
