### PR TITLE
Chore: Remove old typekit reference

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,2 +1,0 @@
-<script src="//use.typekit.net/drg5xfo.js"></script>
-<script>try { Typekit.load({ async: true }); } catch (e) { }</script>


### PR DESCRIPTION
The Typekit reference for the old body font was still in the Playbook docs even though the font wasn't being used. Removing it.