### PR TITLE
Feature: Add unstyled option to Link

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -8,6 +8,8 @@ See [the versioning guidelines](VERSIONING.md) for how to format entries.
 
 ### Enhancements
 
+-   Add unstyled option to `Link` component ([#83](https://github.com/FieldLevel/FieldLevelPlaybook/pull/83))
+
 ### Bug fixes
 
 ### Documentation

--- a/docs/Navigation/Link.stories.mdx
+++ b/docs/Navigation/Link.stories.mdx
@@ -15,13 +15,25 @@ Use Link when the result of the action is the member being taken to another plac
 
 <ArgsTable story="Default" />
 
+## Unstyled
+
+The unstyled option will remove the default link styling to allow Link to be used semantically around different types of elements.
+
+<Canvas>
+    <Story story={stories.Unstyled} />
+</Canvas>
+
 ## External
+
+Use when the link is to an external site.
 
 <Canvas>
     <Story story={stories.External} />
 </Canvas>
 
 ## Click event
+
+Link has an `onClick` to allow an action before the navigation event.
 
 <Canvas>
     <Story story={stories.ClickEvent} />

--- a/docs/Navigation/Link.stories.tsx
+++ b/docs/Navigation/Link.stories.tsx
@@ -9,6 +9,12 @@ export const Default = (args: any) => (
     </Link>
 );
 
+export const Unstyled = () => (
+    <Link unstyled url="https://www.fieldlevel.com">
+        <div className="p-6 border rounded">This whole card is a link.</div>
+    </Link>
+);
+
 export const External = () => (
     <Link external url="https://recruiting.fieldlevel.com">
         Recruiting Guidance

--- a/src/components/Link/Link.module.css
+++ b/src/components/Link/Link.module.css
@@ -1,0 +1,5 @@
+.unstyled {
+	@apply no-underline text-current;
+	@apply hover:no-underline hover:text-current;
+	@apply focus:no-underline focus:text-current;
+}

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -1,19 +1,24 @@
 import React from 'react';
+import cx from 'classnames';
+
+import styles from './Link.module.css';
 
 export interface LinkProps {
     url?: string;
     external?: boolean;
     target?: string;
+    unstyled?: boolean;
     children?: React.ReactNode;
     onClick?(e?: React.MouseEvent<HTMLAnchorElement>): void;
 }
 
-export const Link = ({ url, target, external, children, onClick }: LinkProps) => {
+export const Link = ({ url, target, external, unstyled, children, onClick }: LinkProps) => {
     const targetValue = target || (external ? '_blank' : '');
     const rel = targetValue == '_blank' ? 'noopener noreferrer' : '';
+    const style = cx(unstyled && styles.unstyled);
 
     return (
-        <a href={url} target={targetValue} rel={rel} onClick={onClick}>
+        <a href={url} target={targetValue} rel={rel} className={style} onClick={onClick}>
             {children}
         </a>
     );

--- a/tailwind.preset.js
+++ b/tailwind.preset.js
@@ -32,6 +32,7 @@ module.exports = {
         },
         colors: {
             text: {
+                current: 'currentColor',
                 base: colors.gray[800],
                 muted: colors.gray[500],
                 disabled: colors.gray[300],


### PR DESCRIPTION
Occasionally we want to wrap elements in a `<Link>` to provide the correct semantic indication that the action is a navigation change but find ourselves having to either work around the fact that it applies default anchor tag styling to the child elements. This introduces an `unstyled` option that reverses some of those styles to allow for this use-case.

Resolves https://github.com/FieldLevel/FieldLevelPlaybook/issues/68