### PR TITLE
Feature: Make Modal sizing more flexible

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,6 +10,8 @@ See [the versioning guidelines](VERSIONING.md) for how to format entries.
 
 -   Add unstyled option to `Link` component ([#83](https://github.com/FieldLevel/FieldLevelPlaybook/pull/83))
 
+-   Make `Modal` sizing more flexible ([#84](https://github.com/FieldLevel/FieldLevelPlaybook/pull/84))
+
 ### Bug fixes
 
 ### Documentation

--- a/docs/Overlays/Modal.stories.mdx
+++ b/docs/Overlays/Modal.stories.mdx
@@ -55,6 +55,14 @@ Modal has a max height by design so if the content in the modal body overflows, 
     <Story story={stories.Scrollable} />
 </Canvas>
 
+## Small
+
+Use a small modal when less horizontal space makes the content more readable.
+
+<Canvas>
+    <Story story={stories.Small} />
+</Canvas>
+
 ## Large
 
 Use a large modal when more horizontal space makes the content more readable.

--- a/docs/Overlays/Modal.stories.mdx
+++ b/docs/Overlays/Modal.stories.mdx
@@ -49,7 +49,7 @@ The primary action be made destructive by using the `destructive` flag.
 
 ## Scrollable Body
 
-Modal has a max height by design so if the content in the modal body overflows the body will automatically scroll.
+Modal has a max height by design so if the content in the modal body overflows, the body will scroll.
 
 <Canvas>
     <Story story={stories.Scrollable} />
@@ -57,7 +57,7 @@ Modal has a max height by design so if the content in the modal body overflows t
 
 ## Large
 
-Use a large modal if you have content that requires more space to make it readable.
+Use a large modal when more horizontal space makes the content more readable.
 
 <Canvas>
     <Story story={stories.Large} />

--- a/docs/Overlays/Modal.stories.tsx
+++ b/docs/Overlays/Modal.stories.tsx
@@ -139,6 +139,22 @@ export const Scrollable = () => {
     );
 };
 
+export const Small = () => {
+    const [open, setOpen] = useState(false);
+    const toggleOpen = () => {
+        setOpen(!open);
+    };
+
+    return (
+        <>
+            <Button onClick={toggleOpen}>Open</Button>
+            <Modal title="Small Modal" variant="small" open={open} onDismiss={toggleOpen}>
+                This is a small modal.
+            </Modal>
+        </>
+    );
+};
+
 export const Large = () => {
     const [open, setOpen] = useState(false);
     const toggleOpen = () => {

--- a/src/components/Modal/Modal.module.css
+++ b/src/components/Modal/Modal.module.css
@@ -13,7 +13,7 @@
 }
 
 .large {
-    @apply lg:max-w-screen-xl lg:max-h-screen-m lg:mt-8 lg:mb-8;
+    @apply lg:max-w-screen-lg;
 }
 
 .Header {

--- a/src/components/Modal/Modal.module.css
+++ b/src/components/Modal/Modal.module.css
@@ -2,9 +2,14 @@
     z-index: 9998; /* consider removing this once we clean up the z-index wars in the app */
 }
 
+.Container {
+    @apply fixed top-0 right-0 bottom-0 left-0 flex flex-col justify-center pointer-events-none;
+}
+
 .Content {
-    @apply relative flex flex-col bg-foreground-base text-left overflow-hidden shadow-xl p-0 w-full h-screen m-0;
-    @apply lg:rounded-lg lg:m-auto lg:mt-40 lg:max-w-screen-sm lg:max-h-96 lg:h-auto;
+    @apply relative flex flex-col bg-foreground-base text-left overflow-hidden shadow-xl p-0 w-full h-screen m-0 pointer-events-auto;
+    @apply lg:rounded-lg lg:my-0 lg:mx-auto lg:max-w-screen-sm lg:max-h-screen-m lg:h-auto;
+}
 }
 
 .large {

--- a/src/components/Modal/Modal.module.css
+++ b/src/components/Modal/Modal.module.css
@@ -10,6 +10,9 @@
     @apply relative flex flex-col bg-foreground-base text-left overflow-hidden shadow-xl p-0 w-full h-screen m-0 pointer-events-auto;
     @apply lg:rounded-lg lg:my-0 lg:mx-auto lg:max-w-screen-sm lg:max-h-screen-m lg:h-auto;
 }
+
+.small {
+    @apply lg:max-w-screen-xs;
 }
 
 .large {

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -30,7 +30,7 @@ interface PrimaryAction extends Action {
     destructive?: boolean;
 }
 
-type variant = 'large';
+type variant = 'small' | 'large';
 
 export interface ModalProps {
     open: boolean;
@@ -43,6 +43,7 @@ export interface ModalProps {
 }
 
 const variantStyles: { [key in variant]: string } = {
+    small: styles.small,
     large: styles.large
 };
 

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -88,12 +88,14 @@ export const Modal = ({ open, onDismiss, title, variant, primaryAction, secondar
 
     return (
         <DialogOverlay className={styles.Overlay} isOpen={open} onDismiss={onDismiss}>
-            <DialogContent className={contentStyles} aria-labelledby={labelBy}>
-                {closeContent}
-                {headerContent}
-                {bodyContent}
-                {footerContent}
-            </DialogContent>
+            <div className={styles.Container}>
+                <DialogContent className={contentStyles} aria-labelledby={labelBy}>
+                    {closeContent}
+                    {headerContent}
+                    {bodyContent}
+                    {footerContent}
+                </DialogContent>
+            </div>
         </DialogOverlay>
     );
 };


### PR DESCRIPTION
Fixes some common frustrations with trying to use the `Modal` component in it's current state. The general issue is that the current default Modal sizing is too restrictive and the `large` variant is too wide. This introduces a handful of changes to the `Modal` component to address these issues:

- The default Modal no longer has a fixed max height and will expand to the max height of the viewport minus some margins.
- The `large` variant max width has been reduced down to the `lg` breakpoint instead of `xl`.
- A `small` variant has been introduced with an `xs` breakpoint max width.
- Modal is now vertically centered in the viewport instead of having a fixed top margin.

Resolves #72 