### PR TITLE
Feature: Add secondary Button variant

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -12,6 +12,8 @@ See [the versioning guidelines](VERSIONING.md) for how to format entries.
 
 -   Make `Modal` sizing more flexible ([#84](https://github.com/FieldLevel/FieldLevelPlaybook/pull/84))
 
+-   Add secondary Button variant ([#85](https://github.com/FieldLevel/FieldLevelPlaybook/pull/85))
+
 ### Bug fixes
 
 ### Documentation

--- a/docs/Actions/Button.stories.mdx
+++ b/docs/Actions/Button.stories.mdx
@@ -31,6 +31,14 @@ Use to highlight the most critical action on the page. Don't use more than one p
     <Story story={stories.Primary} />
 </Canvas>
 
+## Secondary
+
+Use as the secondary action when paired with a primary or destructive action. Cancel is the most common example here.
+
+<Canvas>
+    <Story story={stories.Secondary} />
+</Canvas>
+
 ## Plain
 
 Use for less important actions or low-emphasis situations. Plain is commonly paired with basic as a secondary CTA.

--- a/docs/Actions/Button.stories.tsx
+++ b/docs/Actions/Button.stories.tsx
@@ -9,6 +9,8 @@ export const Basic = () => <Button>Continue</Button>;
 
 export const Primary = () => <Button variant="primary">Upgrade</Button>;
 
+export const Secondary = () => <Button variant="secondary">Cancel</Button>;
+
 export const Plain = () => <Button variant="plain">Learn More</Button>;
 
 export const Destructive = () => <Button variant="destructive">Delete</Button>;
@@ -35,6 +37,9 @@ export const Disabled = () => (
         <Button variant="primary" disabled>
             Primary
         </Button>
+        <Button variant="secondary" disabled>
+            Secondary
+        </Button>
         <Button variant="destructive" disabled>
             Destructive
         </Button>
@@ -55,7 +60,7 @@ export const Submit = () => (
             <Button submit variant="primary">
                 Save
             </Button>
-            <Button>Cancel</Button>
+            <Button variant="secondary">Cancel</Button>
         </ButtonGroup>
     </form>
 );

--- a/src/components/Button/Button.module.css
+++ b/src/components/Button/Button.module.css
@@ -12,6 +12,12 @@
     @apply active:bg-primary-pressed;
 }
 
+.secondary {
+    @apply text-base border border-base bg-transparent;
+    @apply hover:bg-secondary-hovered;
+    @apply active:bg-secondary-pressed;
+}
+
 .destructive {
     @apply bg-critical-base text-on-dark border-critical;
     @apply hover:bg-critical-hovered;
@@ -36,6 +42,12 @@
     @apply bg-primary-disabled text-disabled;
     @apply hover:bg-primary-disabled;
     @apply active:bg-primary-disabled;
+}
+
+.secondary.disabled {
+    @apply bg-secondary-disabled text-disabled;
+    @apply hover:bg-secondary-disabled;
+    @apply active:bg-secondary-disabled;
 }
 
 .destructive.disabled {

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -7,7 +7,7 @@ import styles from './Button.module.css';
 
 type size = 'slim' | 'large';
 
-type variant = 'primary' | 'plain' | 'destructive';
+type variant = 'primary' | 'secondary' | 'plain' | 'destructive';
 
 export interface ButtonProps {
     size?: size;
@@ -27,6 +27,7 @@ const sizeStyles: { [key in size]: string } = {
 
 const variantStyles: { [key in variant]: string } = {
     primary: styles.primary,
+    secondary: styles.secondary,
     plain: styles.plain,
     destructive: styles.destructive
 };
@@ -39,6 +40,7 @@ export const Button = ({ size, variant, disabled, fullWidth, submit, icon, onCli
         disabled && styles.disabled,
         fullWidth && styles.fullWidth
     );
+
     const iconContent = icon && (
         <span className={styles.Icon}>
             <Icon source={icon} color="current" />

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -65,7 +65,7 @@ export const Modal = ({ open, onDismiss, title, variant, primaryAction, secondar
         <div className={styles.Footer}>
             <ButtonGroup distribute="end">
                 {secondaryAction && (
-                    <Button onClick={secondaryAction.onAction} disabled={secondaryAction.disabled}>
+                    <Button variant="secondary" onClick={secondaryAction.onAction} disabled={secondaryAction.disabled}>
                         {secondaryAction.content}
                     </Button>
                 )}


### PR DESCRIPTION
This change adds a "secondary" variant to `Button`. We've felt for awhile that our Button is missing a variant that can be more naturally paired with a primary or destructive button. Luckily we already have the color naming and designation for a "secondary" set that we've already used for inputs that makes this an easy add system-wise. This creates the variant and also uses it on `Modal` for the style of the secondary action.