### PR TITLE
Feature: Add url to Button

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -14,6 +14,8 @@ See [the versioning guidelines](VERSIONING.md) for how to format entries.
 
 -   Add secondary Button variant ([#85](https://github.com/FieldLevel/FieldLevelPlaybook/pull/85))
 
+-   Add url to Button ([#86](https://github.com/FieldLevel/FieldLevelPlaybook/pull/86))
+
 ### Bug fixes
 
 ### Documentation

--- a/docs/Actions/Button.stories.mdx
+++ b/docs/Actions/Button.stories.mdx
@@ -87,6 +87,14 @@ Use when you need a button to expand to the full width of it's parent container.
     <Story story={stories.FullWidth} />
 </Canvas>
 
+## Url
+
+You can pass a "url" option to any Button to make sure it's semantically wrapped in a link if the action is a navigation change.
+
+<Canvas>
+    <Story story={stories.Url} />
+</Canvas>
+
 ## Submit
 
 Use the submit option for the Button inside a Form that should trigger the form submit action when clicked.

--- a/docs/Actions/Button.stories.tsx
+++ b/docs/Actions/Button.stories.tsx
@@ -49,6 +49,12 @@ export const Disabled = () => (
     </ButtonGroup>
 );
 
+export const Url = () => (
+    <Button url="http://www.fieldlevel.com" variant="primary">
+        Go to FieldLevel
+    </Button>
+);
+
 export const Submit = () => (
     <form
         onSubmit={(e) => {

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import cx from 'classnames';
 
 import { Icon } from '../Icon';
+import { Link } from '../Link';
 
 import styles from './Button.module.css';
 
@@ -14,6 +15,7 @@ export interface ButtonProps {
     variant?: variant;
     disabled?: boolean;
     fullWidth?: boolean;
+    url?: string;
     submit?: boolean;
     icon?: React.FC<React.SVGProps<SVGSVGElement>>;
     children?: React.ReactNode;
@@ -32,7 +34,7 @@ const variantStyles: { [key in variant]: string } = {
     destructive: styles.destructive
 };
 
-export const Button = ({ size, variant, disabled, fullWidth, submit, icon, onClick, children }: ButtonProps) => {
+export const Button = ({ size, variant, disabled, fullWidth, url, submit, icon, onClick, children }: ButtonProps) => {
     const className = cx(
         styles.Button,
         size && sizeStyles[size],
@@ -47,10 +49,18 @@ export const Button = ({ size, variant, disabled, fullWidth, submit, icon, onCli
         </span>
     );
 
-    return (
+    const buttonContent = (
         <button className={className} disabled={disabled} type={submit ? 'submit' : 'button'} onClick={onClick}>
             {iconContent}
             {children}
         </button>
+    );
+
+    return url ? (
+        <Link unstyled url={url}>
+            {buttonContent}
+        </Link>
+    ) : (
+        buttonContent
     );
 };


### PR DESCRIPTION
This is a quality of life change for something we do a lot with Buttons. Often the action of a button will be to do a navigation change, so if we wanted to be semantically correct the right thing to do would be to wrap the button in an anchor tag, but currently this impacts the styling of the Button that we have to work around or just do a programmatic navigation change which we're trying to move away from as much as possible. With the addition of the `unstyled` option on `Link` we can now handle this properly without impacting the Button style.

Resolves #79 