### PR TITLE
Feature: Allow Select placeholder re-select

### DIFF
--- a/docs/Forms/Select.stories.mdx
+++ b/docs/Forms/Select.stories.mdx
@@ -7,7 +7,7 @@ import * as stories from './Select.stories.tsx';
 
 # Select
 
-Select gives users the ability to make a single selection or multiple choices from several options. Use Select when you have four or more options to avoid noisy lists in the app, when the default option is the recommended option, when a large number of familiar options are available (CA, AZ, NV, OR and etc.), and when you have more than seven options.
+Select gives users the ability to make a single selection from multiple options. Use Select when you have four or more options to avoid noisy lists in the app, when the default option is the recommended option, when a large number of familiar options are available (CA, AZ, NV, OR, etc).
 
 <Canvas>
     <Story story={stories.Default} name="Default" />
@@ -15,13 +15,9 @@ Select gives users the ability to make a single selection or multiple choices fr
 
 <ArgsTable story="Default" />
 
-## Controlled
-
-<Canvas>
-    <Story story={stories.Controlled} />
-</Canvas>
-
 ## Placeholder
+
+Include a placeholder if there is no default selection or initial value.
 
 <Canvas>
     <Story story={stories.Placeholder} />

--- a/docs/Forms/Select.stories.tsx
+++ b/docs/Forms/Select.stories.tsx
@@ -3,11 +3,25 @@ import React, { useState } from 'react';
 
 import { Select } from '../../src';
 
-export const Default = (args: any) => (
-    <Select {...args} label="Sport" name="sport" options={['Baseball', 'Football', 'Basketball']} />
-);
+export const Default = (args: any) => {
+    const [selected, setSelected] = useState();
+    const handleChange = (value) => {
+        setSelected(value);
+    };
 
-export const Controlled = () => {
+    return (
+        <Select
+            {...args}
+            value={selected}
+            label="Sport"
+            name="sport"
+            options={['Baseball', 'Football', 'Basketball']}
+            onChange={handleChange}
+        />
+    );
+};
+
+export const Placeholder = () => {
     const [selected, setSelected] = useState();
     const handleChange = (value) => {
         setSelected(value);
@@ -17,17 +31,13 @@ export const Controlled = () => {
         <Select
             label="Sport"
             name="sport"
-            value={selected}
             options={['Baseball', 'Football', 'Basketball']}
             placeholder="Pick a sport"
+            value={selected}
             onChange={handleChange}
         />
     );
 };
-
-export const Placeholder = () => (
-    <Select label="Sport" name="sport" options={['Baseball', 'Football', 'Basketball']} placeholder="Pick a sport" />
-);
 
 export const Disabled = () => (
     <Select label="Sport" name="sport" options={['Baseball', 'Football', 'Basketball']} disabled />

--- a/src/components/Select/Select.module.css
+++ b/src/components/Select/Select.module.css
@@ -3,7 +3,7 @@
 }
 
 .Select select {
-    @apply rounded-md shadow-sm border border-base py-2 px-3 w-full appearance-none;
+    @apply rounded-md shadow-sm border bg-secondary-base border-base py-2 px-3 w-full appearance-none;
     @apply outline-none focus:ring placeholder-text-muted;
 }
 

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -9,31 +9,39 @@ import { useUniqueId } from '../../utilities/use-unique-id';
 
 import { SelectMinor } from '../../icons/Minor';
 
-interface Option {
+type Option = {
     label: string;
     value: string;
-}
-
-class MyOption implements Option {
-    label: string;
-    value: string;
-
-    constructor(label: string, value: string) {
-        this.label = label;
-        this.value = value;
-    }
-}
+};
 
 export interface SelectProps {
-    options: (Option | string)[];
+    options: (string | Option)[];
     name: string;
     value?: string;
     label?: string;
-    placeholder?: string;
+    placeholder?: string | Option;
     disabled?: boolean;
     error?: string;
     onChange?(value: string, name: string): void;
 }
+
+const standardizeOptions = (options: (string | Option)[]): Option[] => {
+    return options.map((option: string | Option): Option => {
+        if (typeof option === 'string') {
+            return { label: option, value: option } as Option;
+        } else {
+            return option;
+        }
+    });
+};
+
+const standardizePlaceholder = (placeholder: string | Option): Option => {
+    if (typeof placeholder === 'string') {
+        return { label: placeholder, value: placeholder } as Option;
+    } else {
+        return placeholder;
+    }
+};
 
 export const Select = ({ options, name, value, label, placeholder, disabled, error, onChange }: SelectProps) => {
     const id = useUniqueId(name);
@@ -56,25 +64,17 @@ export const Select = ({ options, name, value, label, placeholder, disabled, err
 
     const selectClass = cx(styles.Select, disabled && styles.disabled, error && styles.error);
 
-    const optionsAsOptions: Option[] = options.map(function (option: Option | string): Option {
-        if (typeof option === 'object') {
-            return option;
-        } else {
-            return new MyOption(option, option);
-        }
-    });
+    const stdPlaceholder = placeholder && standardizePlaceholder(placeholder);
+    const stdOptions = standardizeOptions(options);
+    const currentValue = value || (stdPlaceholder && stdPlaceholder.value);
 
     return (
         <div>
             {labelContent}
             <div className={selectClass}>
-                <select id={id} name={name} value={value || placeholder} disabled={disabled} onChange={handleChange}>
-                    {placeholder && (
-                        <option disabled value={placeholder}>
-                            {placeholder}
-                        </option>
-                    )}
-                    {optionsAsOptions.map((option) => (
+                <select id={id} name={name} value={currentValue} disabled={disabled} onChange={handleChange}>
+                    {stdPlaceholder && <option value={stdPlaceholder.value}>{stdPlaceholder.label}</option>}
+                    {stdOptions.map((option) => (
                         <option key={option.value} value={option.value}>
                             {option.label}
                         </option>


### PR DESCRIPTION
This change makes the `Select` placeholder option available for re-selection instead of being disabled, allowing that decision to be handled at the form/input validation level in the application instead. It also allows the placeholder to be either a `string` or `Option` so that the placeholder value can be used in validation if necessary.

Also fixes a Firefox styling issue due to missing background color style.

Resolves #34 
Resolves #66