### PR TITLE
Update mobile Modal variant styles

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,6 +6,8 @@ See [the versioning guidelines](VERSIONING.md) for how to format entries.
 
 ### Enhancements
 
+-   Update mobile Modal variant styles ([#96](https://github.com/FieldLevel/FieldLevelPlaybook/pull/96))
+
 ### Bug fixes
 
 ### Documentation

--- a/src/components/Modal/Modal.module.css
+++ b/src/components/Modal/Modal.module.css
@@ -3,20 +3,30 @@
 }
 
 .Container {
-    @apply fixed top-0 right-0 bottom-0 left-0 flex flex-col justify-center pointer-events-none;
+    @apply fixed top-auto right-0 bottom-0 left-0 flex flex-col justify-center pointer-events-none;
+    @apply lg:top-0 lg:right-0 lg:bottom-0 lg:left-0;
+}
+
+.smallContainer {
+    @apply top-8 right-4 bottom-8 left-4;
+}
+
+.largeContainer {
+    @apply top-0 right-0 bottom-0 left-0;
 }
 
 .Content {
-    @apply relative flex flex-col bg-foreground-base text-left overflow-hidden shadow-xl p-0 w-full h-screen m-0 pointer-events-auto;
-    @apply lg:rounded-lg lg:my-0 lg:mx-auto lg:max-w-screen-sm lg:max-h-screen-m lg:h-auto;
+    @apply relative flex flex-col bg-foreground-base text-left rounded-t-lg overflow-hidden shadow-xl pointer-events-auto;
+    @apply w-full h-auto p-0 m-0 max-h-screen-m;
+    @apply lg:my-0 lg:rounded-lg lg:mx-auto lg:max-w-screen-sm lg:max-h-screen-m lg:h-auto;
 }
 
-.small {
-    @apply lg:max-w-screen-xs;
+.smallContent {
+    @apply max-h-screen-m rounded-lg lg:max-w-screen-xs;
 }
 
-.large {
-    @apply lg:max-w-screen-lg;
+.largeContent {
+    @apply h-screen max-h-screen rounded-none lg:rounded-lg lg:max-w-screen-lg;
 }
 
 .Header {

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -42,9 +42,14 @@ export interface ModalProps {
     children?: React.ReactNode;
 }
 
-const variantStyles: { [key in variant]: string } = {
-    small: styles.small,
-    large: styles.large
+const variantContainerStyles: { [key in variant]: string } = {
+    small: styles.smallContainer,
+    large: styles.largeContainer
+};
+
+const variantContentStyles: { [key in variant]: string } = {
+    small: styles.smallContent,
+    large: styles.largeContent
 };
 
 export const Modal = ({ open, onDismiss, title, variant, primaryAction, secondaryAction, children }: ModalProps) => {
@@ -85,11 +90,12 @@ export const Modal = ({ open, onDismiss, title, variant, primaryAction, secondar
     );
 
     const labelBy = title ? headerId : bodyId;
-    const contentStyles = cx(styles.Content, variant && variantStyles[variant]);
+    const containerStyles = cx(styles.Container, variant && variantContainerStyles[variant]);
+    const contentStyles = cx(styles.Content, variant && variantContentStyles[variant]);
 
     return (
         <DialogOverlay className={styles.Overlay} isOpen={open} onDismiss={onDismiss}>
-            <div className={styles.Container}>
+            <div className={containerStyles}>
                 <DialogContent className={contentStyles} aria-labelledby={labelBy}>
                     {closeContent}
                     {headerContent}


### PR DESCRIPTION
Updates the `Modal` styles for mobile screens to be bit more flexible in use than always being a full-screen takeover like it has been. The changes are as follows:

Small variant stays centered in the viewport sized to the content and grows to the full viewport minus some margins surrounding:

<img src="https://user-images.githubusercontent.com/932981/206293652-8ff0a92c-18b1-4f6f-9709-1daf1538aea0.png" width="250" />

Default variant docks to the bottom of the viewport sized to the content and grows to fill almost the entire viewport:

<img src="https://user-images.githubusercontent.com/932981/206293886-16d9dfe7-d8d8-44fa-b366-9010b71ca8a1.png" width="250" />

Large variant remains as a full-screen takeover:

<img src="https://user-images.githubusercontent.com/932981/206293971-46058651-27d9-478b-a7db-b3f9c7d3370d.png" width="250" />
