### PR TITLE
Chore: Upgrade to React 17 and Node 18

### DIFF
--- a/.github/workflows/github-package-publish.yml
+++ b/.github/workflows/github-package-publish.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Use Node
         uses: actions/setup-node@v2
         with:
-          node-version: '14.x'
+          node-version: '18.17'
           registry-url: 'https://npm.pkg.github.com'
           scope: '@fieldlevel'
           cache: 'yarn'

--- a/.github/workflows/lint-on-pr.yml
+++ b/.github/workflows/lint-on-pr.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Use Node
         uses: actions/setup-node@v2
         with:
-          node-version: '14.x'
+          node-version: '18.17'
           cache: 'yarn'
       - name: Install dependencies
         run: yarn --frozen-lockfile --ignore-scripts

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -14,6 +14,8 @@ See [the versioning guidelines](VERSIONING.md) for how to format entries.
 
 ### Dependency upgrades
 
+-   Upgrade to React 17 and Node 18 ([#109](https://github.com/FieldLevel/FieldLevelPlaybook/pull/109))
+
 ### Code quality
 
 ### Deprecations

--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
     "prepare": "yarn run build",
     "build": "node ./scripts/build.js",
     "lint": "eslint --ext .ts,.tsx src docs --max-warnings=0",
-    "start": "SET NODE_OPTIONS=--openssl-legacy-provider && start-storybook -p 6006 --no-manager-cache --ci",
-    "start-docs": "SET NODE_OPTIONS=--openssl-legacy-provider && start-storybook --docs -p 6007",
-    "build-docs": "SET NODE_OPTIONS=--openssl-legacy-provider && build-storybook --docs --quiet -o public",
+    "start": "cross-env NODE_OPTIONS=--openssl-legacy-provider start-storybook -p 6006 --no-manager-cache --ci",
+    "start-docs": "cross-env NODE_OPTIONS=--openssl-legacy-provider start-storybook --docs -p 6007",
+    "build-docs": "cross-env NODE_OPTIONS=--openssl-legacy-provider build-storybook --docs --quiet -o public",
     "generate-icons": "node ./scripts/generate-icons.js"
   },
   "dependencies": {
@@ -50,6 +50,7 @@
     "autoprefixer": "^10.4.14",
     "babel-loader": "^8.2.2",
     "cpy-cli": "^3.1.1",
+    "cross-env": "^7.0.3",
     "eslint": "^6.0.0",
     "eslint-config-prettier": "^6.15.0",
     "eslint-plugin-prettier": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
   "dependencies": {
     "@reach/dialog": "^0.17.0",
     "classnames": "^2.2.6",
-    "react": "^16.14.0",
-    "react-dom": "^16.14.0",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
     "react-intersection-observer": "^9.4.0"
   },
   "peerDependencies": {},
@@ -43,8 +43,8 @@
     "@storybook/react": "^6.5.12",
     "@svgr/cli": "^5.5.0",
     "@types/classnames": "^2.2.11",
-    "@types/react": "^16",
-    "@types/react-dom": "^16",
+    "@types/react": "^17",
+    "@types/react-dom": "^17",
     "@typescript-eslint/eslint-plugin": "^2.3.3",
     "@typescript-eslint/parser": "^2.3.3",
     "autoprefixer": "^10.4.14",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "url": "git://github.com/FieldLevel/FieldLevelPlaybook.git"
   },
   "engines": {
-    "node": ">=14.15",
-    "yarn": ">=1.22.5",
+    "node": ">=18.17",
+    "yarn": ">=1.22.19",
     "npm": "use yarn!"
   },
   "module": "dist/index.js",
@@ -20,11 +20,10 @@
     "prepare": "yarn run build",
     "build": "node ./scripts/build.js",
     "lint": "eslint --ext .ts,.tsx src docs --max-warnings=0",
-    "start": "start-storybook -p 6006 --no-manager-cache --ci",
-    "start-docs": "start-storybook --docs -p 6007",
-    "build-docs": "build-storybook --docs --quiet -o public",
-    "generate-icons": "node ./scripts/generate-icons.js",
-    "refresh-vs-token": "vsts-npm-auth -config .npmrc"
+    "start": "SET NODE_OPTIONS=--openssl-legacy-provider && start-storybook -p 6006 --no-manager-cache --ci",
+    "start-docs": "SET NODE_OPTIONS=--openssl-legacy-provider && start-storybook --docs -p 6007",
+    "build-docs": "SET NODE_OPTIONS=--openssl-legacy-provider && build-storybook --docs --quiet -o public",
+    "generate-icons": "node ./scripts/generate-icons.js"
   },
   "dependencies": {
     "@reach/dialog": "^0.17.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4715,6 +4715,13 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+cross-env@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
+  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
 cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -4726,7 +4733,7 @@ cross-spawn@^6.0.0, cross-spawn@^6.0.5:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^7.0.0, cross-spawn@^7.0.3:
+cross-spawn@^7.0.0, cross-spawn@^7.0.1, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2738,17 +2738,17 @@
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.6.tgz#df9c3c8b31a247ec315e6996566be3171df4b3b1"
   integrity sha512-0/HnwIfW4ki2D8L8c9GVcG5I72s9jP5GSLVF0VIXDW00kmIpA6O33G7a8n59Tmh7Nz0WUC3rSb7PTY/sdW2JzA==
 
-"@types/react-dom@^16":
-  version "16.9.16"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.16.tgz#c591f2ed1c6f32e9759dfa6eb4abfd8041f29e39"
-  integrity sha512-Oqc0RY4fggGA3ltEgyPLc3IV9T73IGoWjkONbsyJ3ZBn+UPPCYpU2ec0i3cEbJuEdZtkqcCF2l1zf2pBdgUGSg==
+"@types/react-dom@^17":
+  version "17.0.20"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.20.tgz#e0c8901469d732b36d8473b40b679ad899da1b53"
+  integrity sha512-4pzIjSxDueZZ90F52mU3aPoogkHIoSIDG+oQ+wQK7Cy2B9S+MvOqY0uEA/qawKz381qrEDkvpwyt8Bm31I8sbA==
   dependencies:
-    "@types/react" "^16"
+    "@types/react" "^17"
 
-"@types/react@^16":
-  version "16.14.32"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.14.32.tgz#d4e4fe5ece3c27fcb4608b1f4a614f7dec881392"
-  integrity sha512-hvEy4vGVADbtj/U6+CA5SRC5QFIjdxD7JslAie8EuAYZwhYY9bgforpXNyF1VFzhnkEOesDy1278t1wdjN74cw==
+"@types/react@^17":
+  version "17.0.65"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.65.tgz#95f6a2ab61145ffb69129d07982d047f9e0870cd"
+  integrity sha512-oxur785xZYHvnI7TRS61dXbkIhDPnGfsXKv0cNXR/0ml4SipRIFpSMzA7HMEfOywFwJ5AOnPrXYTEiTRUQeGlQ==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -10061,15 +10061,14 @@ react-docgen@^5.0.0:
     node-dir "^0.1.10"
     strip-indent "^3.0.0"
 
-react-dom@^16.14.0:
-  version "16.14.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.14.0.tgz#7ad838ec29a777fb3c75c3a190f661cf92ab8b89"
-  integrity sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==
+react-dom@^17.0.2:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"
+  integrity sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    scheduler "^0.19.1"
+    scheduler "^0.20.2"
 
 react-element-to-jsx-string@^14.3.4:
   version "14.3.4"
@@ -10149,14 +10148,13 @@ react-style-singleton@^2.2.1:
     invariant "^2.2.4"
     tslib "^2.0.0"
 
-react@^16.14.0:
-  version "16.14.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.14.0.tgz#94d776ddd0aaa37da3eda8fc5b6b18a4c9a3114d"
-  integrity sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==
+react@^17.0.2:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
+  integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    prop-types "^15.6.2"
 
 read-cache@^1.0.0:
   version "1.0.0"
@@ -10695,10 +10693,10 @@ sax@^1.2.4, sax@~1.2.4:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
-scheduler@^0.19.1:
-  version "0.19.1"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.19.1.tgz#4f3e2ed2c1a7d65681f4c854fa8c5a1ccb40f196"
-  integrity sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==
+scheduler@^0.20.2:
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.2.tgz#4baee39436e34aa93b4874bddcbf0fe8b8b50e91"
+  integrity sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
Upgrades project dependencies to use React v17.0.2 and build configuration to require Node 18 and Yarn 1.22.19.