### PR TITLE
Fix issues with TextInput

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -19,3 +19,5 @@ See [the versioning guidelines](VERSIONING.md) for how to format entries.
 ### Code quality
 
 ### Deprecations
+
+-   Remove deprecated `multiline` prop from `TextInput` ([#112](https://github.com/FieldLevel/FieldLevelPlaybook/pull/112))

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -8,6 +8,8 @@ See [the versioning guidelines](VERSIONING.md) for how to format entries.
 
 ### Bug fixes
 
+-   Fix issues with TextInput ([#112](https://github.com/FieldLevel/FieldLevelPlaybook/pull/112))
+
 ### Documentation
 
 ### Development workflow

--- a/docs/Forms/TextInput.stories.mdx
+++ b/docs/Forms/TextInput.stories.mdx
@@ -83,10 +83,10 @@ Use when anticipating longer values. Controlled by the minimum number of `rows` 
     <Story story={stories.Rows} />
 </Canvas>
 
-## Focus
+## Ref
 
-You can set focus on the underlying HTML element by utilizing the `ref` prop.
+You can get access to the ref of the inner input or textarea element by utilizing the `ref` prop.
 
 <Canvas>
-    <Story story={stories.Focus} />
+    <Story story={stories.Ref} />
 </Canvas>

--- a/docs/Forms/TextInput.stories.tsx
+++ b/docs/Forms/TextInput.stories.tsx
@@ -2,7 +2,6 @@
 import React, { useRef, useState } from 'react';
 
 import { TextInput, FormLayout, Button, Stack } from '../../src';
-import type { TextInputRef } from '../../src/components/TextInput';
 import { SearchMinor } from '../../src';
 
 export const Default = (args: any) => <TextInput {...args} label="Headline" name="headline" />;
@@ -63,17 +62,28 @@ export const MaxLength = () => <TextInput label="Headline" name="headline" maxLe
 
 export const Rows = () => <TextInput label="Headline" name="headline" rows={3} maxRows={5} />;
 
-export const Focus = () => {
-    const inputRef = useRef<TextInputRef>(null);
+export const Ref = () => {
+    const inputRef = useRef<HTMLInputElement>(null);
+    const textAreaRef = useRef<HTMLTextAreaElement>(null);
 
     const focusInput = () => {
         inputRef.current?.focus();
     };
 
+    const focusTextArea = () => {
+        textAreaRef.current?.focus();
+    };
+
     return (
-        <Stack align="end">
-            <TextInput label="Headline" name="headline" ref={inputRef} />
-            <Button onClick={focusInput}>Focus!</Button>
-        </Stack>
+        <>
+            <Stack align="end">
+                <TextInput label="Input" name="input" ref={inputRef} />
+                <Button onClick={focusInput}>Focus!</Button>
+            </Stack>
+            <Stack align="end">
+                <TextInput rows={3} label="TextArea" name="textarea" ref={textAreaRef} />
+                <Button onClick={focusTextArea}>Focus!</Button>
+            </Stack>
+        </>
     );
 };

--- a/src/components/TextInput/TextInput.module.css
+++ b/src/components/TextInput/TextInput.module.css
@@ -4,7 +4,7 @@
 
 .TextInput input,
 .TextInput textarea {
-    @apply rounded-md shadow-sm border border-base py-2 px-3 w-full max-h-40 align-bottom resize-none;
+    @apply rounded-md shadow-sm border border-base py-2 px-3 w-full align-bottom resize-none;
     @apply outline-none focus:ring placeholder-text-muted;
     line-height: 20px;
     min-height: 40px;

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -39,10 +39,6 @@ export interface TextInputProps {
     action?: Action;
     value?: string;
     placeholder?: string;
-    /**
-     * @deprecated Use rows and maxRows instead
-     */
-    multiline?: boolean;
     rows?: number;
     maxRows?: number;
     maxLength?: number;
@@ -61,7 +57,6 @@ export const TextInput = React.forwardRef(function TextInput(
         action,
         value,
         placeholder,
-        multiline,
         rows,
         maxRows,
         maxLength,
@@ -79,13 +74,6 @@ export const TextInput = React.forwardRef(function TextInput(
     const textAreaRef = useRef<HTMLTextAreaElement>(null);
 
     useImperativeHandle(forwardedRef, () => (rows ? textAreaRef?.current : inputRef?.current));
-
-    if (multiline) {
-        rows = 3;
-        console.warn(
-            `TextInput :: The multiline prop has been deprecated. Use rows and maxRows to control multiline behavior.`
-        );
-    }
 
     let multiMaxRows: number;
     if (rows) {

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -32,10 +32,6 @@ type Action = {
     onClick?(): void;
 };
 
-export type TextInputRef = {
-    focus: () => void;
-};
-
 export interface TextInputProps {
     name: string;
     type?: Type;
@@ -75,19 +71,14 @@ export const TextInput = React.forwardRef(function TextInput(
         error,
         onChange
     }: TextInputProps,
-    forwardedRef: Ref<TextInputRef>
+    forwardedRef: Ref<HTMLInputElement | HTMLTextAreaElement | null>
 ) {
     const id = useUniqueId(name);
     const [currentRows, setCurrentRows] = useState(rows);
     const inputRef = useRef<HTMLInputElement>(null);
     const textAreaRef = useRef<HTMLTextAreaElement>(null);
 
-    useImperativeHandle(forwardedRef, () => ({
-        focus: () => {
-            const el = inputRef?.current || textAreaRef?.current;
-            el?.focus();
-        }
-    }));
+    useImperativeHandle(forwardedRef, () => (rows ? textAreaRef?.current : inputRef?.current));
 
     if (multiline) {
         rows = 3;


### PR DESCRIPTION
Updates the `forwardRef` behavior for `TextInput` to provide the full ref to the inner `HTMLInputElement` or `HTMLTextAreaElement` instead of our custom imperative handle that previously only exposed the `focus()` functionality. This should not be a breaking change since focus will still work as before.

Additionally removes the `max-height` style on the the input that was preventing any `TextInput` with a `maxRows` higher than 7 from working and removes the previously deprecated `multiline` prop.

Fixes #111 and #99.