### PR TITLE
Fix issues with Button and Link

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -9,6 +9,7 @@ See [the versioning guidelines](VERSIONING.md) for how to format entries.
 ### Bug fixes
 
 -   Fix issues with TextInput ([#112](https://github.com/FieldLevel/FieldLevelPlaybook/pull/112))
+-   Fix issues with Button and Link ([#113](https://github.com/FieldLevel/FieldLevelPlaybook/pull/113))
 
 ### Documentation
 

--- a/docs/Actions/Button.stories.mdx
+++ b/docs/Actions/Button.stories.mdx
@@ -102,3 +102,11 @@ Use the submit option for the Button inside a Form that should trigger the form 
 <Canvas>
     <Story story={stories.Submit} />
 </Canvas>
+
+## Ref
+
+You can get access to the ref of the inner button element by utilizing the `ref` prop.
+
+<Canvas>
+    <Story story={stories.Ref} />
+</Canvas>

--- a/docs/Actions/Button.stories.mdx
+++ b/docs/Actions/Button.stories.mdx
@@ -95,6 +95,14 @@ You can pass a "url" option to any Button to make sure it's semantically wrapped
     <Story story={stories.Url} />
 </Canvas>
 
+## Accessibility
+
+Use the `ariaLabel` or `ariaLabelledBy` props to provide accessible button labels for any Button without a label.
+
+<Canvas>
+    <Story story={stories.Accessibility} />
+</Canvas>
+
 ## Submit
 
 Use the submit option for the Button inside a Form that should trigger the form submit action when clicked.

--- a/docs/Actions/Button.stories.mdx
+++ b/docs/Actions/Button.stories.mdx
@@ -89,7 +89,7 @@ Use when you need a button to expand to the full width of it's parent container.
 
 ## Url
 
-You can pass a "url" option to any Button to make sure it's semantically wrapped in a link if the action is a navigation change.
+You can pass `url` and/or `target` props to any Button to make sure it's semantically wrapped in a link if the action is a navigation change.
 
 <Canvas>
     <Story story={stories.Url} />

--- a/docs/Actions/Button.stories.tsx
+++ b/docs/Actions/Button.stories.tsx
@@ -55,9 +55,14 @@ export const Disabled = () => (
 );
 
 export const Url = () => (
-    <Button url="http://www.fieldlevel.com" variant="primary">
-        Go to FieldLevel
-    </Button>
+    <ButtonGroup>
+        <Button url="https://www.fieldlevel.com" variant="primary">
+            Go to FieldLevel
+        </Button>
+        <Button url="https://support.fieldlevel.com" target="_blank" variant="primary">
+            FieldLevel Support
+        </Button>
+    </ButtonGroup>
 );
 
 export const Accessibility = () => (

--- a/docs/Actions/Button.stories.tsx
+++ b/docs/Actions/Button.stories.tsx
@@ -32,7 +32,12 @@ export const Size = () => (
 
 export const FullWidth = () => (
     <div className="w-80">
-        <Button fullWidth>Full Width</Button>
+        <ButtonGroup vertical>
+            <Button fullWidth>Full width</Button>
+            <Button fullWidth url="https://www.fieldlevel.com">
+                Full width with link
+            </Button>
+        </ButtonGroup>
     </div>
 );
 

--- a/docs/Actions/Button.stories.tsx
+++ b/docs/Actions/Button.stories.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import React from 'react';
+import React, { useRef } from 'react';
 
 import { Button, ButtonGroup, AddMinor } from '../../src';
 
@@ -70,3 +70,21 @@ export const Submit = () => (
         </ButtonGroup>
     </form>
 );
+
+export const Ref = () => {
+    const buttonRef = useRef<HTMLButtonElement>(null);
+    const focusButton = () => {
+        buttonRef.current?.focus();
+    };
+
+    return (
+        <ButtonGroup>
+            <Button variant="primary" ref={buttonRef}>
+                Save
+            </Button>
+            <Button variant="secondary" onClick={focusButton}>
+                Don&apos;t cancel, save!
+            </Button>
+        </ButtonGroup>
+    );
+};

--- a/docs/Actions/Button.stories.tsx
+++ b/docs/Actions/Button.stories.tsx
@@ -15,7 +15,12 @@ export const Plain = () => <Button variant="plain">Learn More</Button>;
 
 export const Destructive = () => <Button variant="destructive">Delete</Button>;
 
-export const Icon = () => <Button icon={AddMinor}>Add Athlete</Button>;
+export const Icon = () => (
+    <ButtonGroup>
+        <Button icon={AddMinor}>Add Athlete</Button>
+        <Button icon={AddMinor} />
+    </ButtonGroup>
+);
 
 export const Size = () => (
     <ButtonGroup>

--- a/docs/Actions/Button.stories.tsx
+++ b/docs/Actions/Button.stories.tsx
@@ -60,6 +60,18 @@ export const Url = () => (
     </Button>
 );
 
+export const Accessibility = () => (
+    <>
+        <div className="mb-4">
+            <Button icon={AddMinor} ariaLabel="Add" />
+        </div>
+        <ButtonGroup>
+            <Button icon={AddMinor} ariaLabelledBy="label" />
+            <div id="label">Some other label for the button</div>
+        </ButtonGroup>
+    </>
+);
+
 export const Submit = () => (
     <form
         onSubmit={(e) => {

--- a/docs/Navigation/Link.stories.mdx
+++ b/docs/Navigation/Link.stories.mdx
@@ -23,12 +23,12 @@ The unstyled option will remove the default link styling to allow Link to be use
     <Story story={stories.Unstyled} />
 </Canvas>
 
-## External
+## Target
 
-Use when the link is to an external site.
+Use `target` to control link opening behavior.
 
 <Canvas>
-    <Story story={stories.External} />
+    <Story story={stories.Target} />
 </Canvas>
 
 ## Click event

--- a/docs/Navigation/Link.stories.tsx
+++ b/docs/Navigation/Link.stories.tsx
@@ -15,8 +15,8 @@ export const Unstyled = () => (
     </Link>
 );
 
-export const External = () => (
-    <Link external url="https://recruiting.fieldlevel.com">
+export const Target = () => (
+    <Link url="https://recruiting.fieldlevel.com" target="_blank">
         Recruiting Guidance
     </Link>
 );

--- a/src/components/Button/Button.module.css
+++ b/src/components/Button/Button.module.css
@@ -74,6 +74,6 @@
     @apply w-full justify-center;
 }
 
-.Icon {
+.iconWithLabel {
     @apply -ml-1 mr-2;
 }

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import type { Ref } from 'react';
 import cx from 'classnames';
 
 import { Icon } from '../Icon';
@@ -34,7 +35,10 @@ const variantStyles: { [key in variant]: string } = {
     destructive: styles.destructive
 };
 
-export const Button = ({ size, variant, disabled, fullWidth, url, submit, icon, onClick, children }: ButtonProps) => {
+export const Button = React.forwardRef(function Button(
+    { size, variant, disabled, fullWidth, url, submit, icon, onClick, children }: ButtonProps,
+    forwardedRef: Ref<HTMLButtonElement>
+) {
     const className = cx(
         styles.Button,
         size && sizeStyles[size],
@@ -50,7 +54,13 @@ export const Button = ({ size, variant, disabled, fullWidth, url, submit, icon, 
     );
 
     const buttonContent = (
-        <button className={className} disabled={disabled} type={submit ? 'submit' : 'button'} onClick={onClick}>
+        <button
+            ref={forwardedRef}
+            className={className}
+            disabled={disabled}
+            type={submit ? 'submit' : 'button'}
+            onClick={onClick}
+        >
             {iconContent}
             {children}
         </button>
@@ -63,4 +73,4 @@ export const Button = ({ size, variant, disabled, fullWidth, url, submit, icon, 
     ) : (
         buttonContent
     );
-};
+});

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -35,11 +35,25 @@ const variantStyles: { [key in variant]: string } = {
     destructive: styles.destructive
 };
 
+const hasChildren = (children: React.ReactNode): boolean => {
+    const count = React.Children.count(children);
+    return count > 0;
+};
+
 export const Button = React.forwardRef(function Button(
     { size, variant, disabled, fullWidth, url, submit, icon, onClick, children }: ButtonProps,
     forwardedRef: Ref<HTMLButtonElement>
 ) {
-    const className = cx(
+    const hasLabel = hasChildren(children);
+    const iconClassName = cx(hasLabel && styles.iconWithLabel);
+
+    const iconContent = icon && (
+        <span className={iconClassName}>
+            <Icon source={icon} color="current" />
+        </span>
+    );
+
+    const buttonClassName = cx(
         styles.Button,
         size && sizeStyles[size],
         variant && variantStyles[variant],
@@ -47,16 +61,10 @@ export const Button = React.forwardRef(function Button(
         fullWidth && styles.fullWidth
     );
 
-    const iconContent = icon && (
-        <span className={styles.Icon}>
-            <Icon source={icon} color="current" />
-        </span>
-    );
-
     const buttonContent = (
         <button
             ref={forwardedRef}
-            className={className}
+            className={buttonClassName}
             disabled={disabled}
             type={submit ? 'submit' : 'button'}
             onClick={onClick}

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -19,6 +19,8 @@ export interface ButtonProps {
     url?: string;
     submit?: boolean;
     icon?: React.FC<React.SVGProps<SVGSVGElement>>;
+    ariaLabel?: string;
+    ariaLabelledBy?: string;
     children?: React.ReactNode;
     onClick?(): void;
 }
@@ -41,7 +43,19 @@ const hasChildren = (children: React.ReactNode): boolean => {
 };
 
 export const Button = React.forwardRef(function Button(
-    { size, variant, disabled, fullWidth, url, submit, icon, onClick, children }: ButtonProps,
+    {
+        size,
+        variant,
+        disabled,
+        fullWidth,
+        url,
+        submit,
+        icon,
+        ariaLabel,
+        ariaLabelledBy,
+        onClick,
+        children
+    }: ButtonProps,
     forwardedRef: Ref<HTMLButtonElement>
 ) {
     const hasLabel = hasChildren(children);
@@ -67,6 +81,8 @@ export const Button = React.forwardRef(function Button(
             className={buttonClassName}
             disabled={disabled}
             type={submit ? 'submit' : 'button'}
+            aria-label={ariaLabel}
+            aria-labelledby={ariaLabelledBy}
             onClick={onClick}
         >
             {iconContent}

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -17,6 +17,7 @@ export interface ButtonProps {
     disabled?: boolean;
     fullWidth?: boolean;
     url?: string;
+    target?: string;
     submit?: boolean;
     icon?: React.FC<React.SVGProps<SVGSVGElement>>;
     ariaLabel?: string;
@@ -49,6 +50,7 @@ export const Button = React.forwardRef(function Button(
         disabled,
         fullWidth,
         url,
+        target,
         submit,
         icon,
         ariaLabel,
@@ -91,7 +93,7 @@ export const Button = React.forwardRef(function Button(
     );
 
     return url ? (
-        <Link unstyled url={url}>
+        <Link unstyled url={url} target={target}>
             {buttonContent}
         </Link>
     ) : (

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -93,7 +93,7 @@ export const Button = React.forwardRef(function Button(
     );
 
     return url ? (
-        <Link unstyled url={url} target={target}>
+        <Link unstyled fullWidth={fullWidth} url={url} target={target}>
             {buttonContent}
         </Link>
     ) : (

--- a/src/components/Link/Link.module.css
+++ b/src/components/Link/Link.module.css
@@ -3,3 +3,7 @@
 	@apply hover:no-underline hover:text-current;
 	@apply focus:no-underline focus:text-current;
 }
+
+.fullWidth {
+    @apply w-full;
+}

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -11,14 +11,15 @@ export interface LinkProps {
     external?: boolean;
     target?: string;
     unstyled?: boolean;
+    fullWidth?: boolean;
     children?: React.ReactNode;
     onClick?(e?: React.MouseEvent<HTMLAnchorElement>): void;
 }
 
-export const Link = ({ url, target, external, unstyled, children, onClick }: LinkProps) => {
+export const Link = ({ url, target, external, unstyled, fullWidth, children, onClick }: LinkProps) => {
     const targetValue = target || (external ? '_blank' : '');
     const rel = targetValue == '_blank' ? 'noopener noreferrer' : '';
-    const style = cx(unstyled && styles.unstyled);
+    const style = cx(unstyled && styles.unstyled, fullWidth && styles.fullWidth);
 
     if (external) {
         console.warn(`Link :: The external prop has been deprecated. Use target instead.`);

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -5,6 +5,9 @@ import styles from './Link.module.css';
 
 export interface LinkProps {
     url?: string;
+    /**
+     * @deprecated Use target instead
+     */
     external?: boolean;
     target?: string;
     unstyled?: boolean;
@@ -16,6 +19,10 @@ export const Link = ({ url, target, external, unstyled, children, onClick }: Lin
     const targetValue = target || (external ? '_blank' : '');
     const rel = targetValue == '_blank' ? 'noopener noreferrer' : '';
     const style = cx(unstyled && styles.unstyled);
+
+    if (external) {
+        console.warn(`Link :: The external prop has been deprecated. Use target instead.`);
+    }
 
     return (
         <a href={url} target={targetValue} rel={rel} className={style} onClick={onClick}>


### PR DESCRIPTION
Fixes a handful of outstanding issues with the `Button` and `Link` components.

- Adds a `forwardRef` to the underlying `<button>` element to make things like focusing a `Button` programmatically possible. Fixes #101 
- Fixes a styling bug when a `Button` has only an `icon` prop and no content. Fixes #104 
- Adds accessibility props to `Button`. Fixes #108 
- Adds `target` prop to `Button` for use when passing a `url`.
- Marks the `external` prop on `Link` as deprecated. Fixes #106 
- Adds a `fullWidth` prop to `Link` and passes it through from `Button` to fix various styling issues. Fixes #107

None of these are breaking changes.