### PR TITLE
Fix Modal focusing close button on open

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,6 +10,7 @@ See [the versioning guidelines](VERSIONING.md) for how to format entries.
 
 -   Fix issues with TextInput ([#112](https://github.com/FieldLevel/FieldLevelPlaybook/pull/112))
 -   Fix issues with Button and Link ([#113](https://github.com/FieldLevel/FieldLevelPlaybook/pull/113))
+-   Fix Modal focusing close button on open ([#114](https://github.com/FieldLevel/FieldLevelPlaybook/pull/114))
 
 ### Documentation
 

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -58,7 +58,7 @@ export const Modal = ({ open, onDismiss, title, variant, primaryAction, secondar
 
     const closeContent = (
         <div className={styles.Close}>
-            <button onClick={onDismiss}>
+            <button aria-label="Close dialog" onClick={onDismiss}>
                 <Icon source={CloseMajor} />
             </button>
         </div>
@@ -96,11 +96,11 @@ export const Modal = ({ open, onDismiss, title, variant, primaryAction, secondar
     return (
         <DialogOverlay className={styles.Overlay} isOpen={open} onDismiss={onDismiss}>
             <div className={containerStyles}>
-                <DialogContent className={contentStyles} aria-labelledby={labelBy}>
-                    {closeContent}
+                <DialogContent tabIndex={0} className={contentStyles} aria-labelledby={labelBy}>
                     {headerContent}
                     {bodyContent}
                     {footerContent}
+                    {closeContent}
                 </DialogContent>
             </div>
         </DialogOverlay>

--- a/src/styles.css
+++ b/src/styles.css
@@ -23,6 +23,10 @@
         @apply hover:text-interactive-hover hover:underline;
     }
 
+    button {
+        @apply focus:ring;
+    }
+
     b,
     strong {
         @apply font-bold;


### PR DESCRIPTION
Adds a `tabIndex` to modal content to be the initial focus and moves the close button to the end of content so that it remains in the tabbable items but at the end. Adds an accessibility label to the close button.

Also adds a focus ring to the base `button` style that was hiding this issue in the Playbook docs/sandbox.

Fixes #97