### PR TITLE
Fix remove invalid aria role on logo

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,6 +6,9 @@ See [the versioning guidelines](VERSIONING.md) for how to format entries.
 
 ### Enhancements
 
+- Remove unnecessary/invalid "role='img'" on `Logo` container
+- Remove unnecessary/invalid "role='img'" on `Avatar` container
+
 ### Bug fixes
 
 ### Documentation

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -33,7 +33,7 @@ export const Avatar = ({ source, size, alt, title, lazy = false }: AvatarProps) 
     const finalAlt = alt ?? title;
 
     return (
-        <span role="img" className={avatarStyle}>
+        <span className={avatarStyle}>
             {lazy ? (
                 <LazyImage
                     src={source}

--- a/src/components/Logo/Logo.tsx
+++ b/src/components/Logo/Logo.tsx
@@ -33,7 +33,7 @@ export const Logo = ({ source, size, alt, title, lazy = false }: LogoProps) => {
     const finalAlt = alt ?? title;
 
     return (
-        <span role="img" className={logoStyle}>
+        <span className={logoStyle}>
             {lazy ? (
                 <LazyImage
                     src={source}


### PR DESCRIPTION
This PR removes an invalid "role='img'" declaration on the containing `<span>` inside both Logo + Avatar. The purpose of "role='img'" is generally to describe an image that's composed of multiple images, code samples, etc. and when it's included, it should have alt text. Since in this situation we're just showing a single image, and it's already aria compliant, this role unnecessary/invalid.

The reason this was discovered was that the automated accessibility tester on webpagetest.org marked it as a "serious" issue on some of our public pages.

Asana Link: https://app.asana.com/0/1205633609426968/1205837694200797/f
It's up on QA-8 (using a locally built version of Playbook)