### PR TITLE
Chore add srcset to logo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ yarn-debug.log*
 yarn-error.log*
 
 .next
+
+# Ignore IntelliJ project settings
+.idea

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -8,6 +8,7 @@ See [the versioning guidelines](VERSIONING.md) for how to format entries.
 
 - Add srcSet support on Logo
 - Add srcSet support on LazyImage
+- Add srcSet support on Avatar
 
 ### Bug fixes
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,11 +6,18 @@ See [the versioning guidelines](VERSIONING.md) for how to format entries.
 
 ### Enhancements
 
+- Add srcSet support on Logo
+- Add srcSet support on LazyImage
+
 ### Bug fixes
+
+- Fix invalid aria role on LazyImage
 
 ### Documentation
 
 ### Development workflow
+
+- Ignore IntelliJ IDE project settings (.idea folder)
 
 ### Dependency upgrades
 

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -9,6 +9,7 @@ type pixelSize = size | 'base';
 
 export interface AvatarProps {
     source: string;
+    sourceSet?: string;
     size?: size;
     alt?: string;
     title?: string;
@@ -26,7 +27,7 @@ const sizeInPixels: { [key in pixelSize]: number } = {
     large: 60
 };
 
-export const Avatar = ({ source, size, alt, title, lazy = false }: AvatarProps) => {
+export const Avatar = ({ source, sourceSet, size, alt, title, lazy = false }: AvatarProps) => {
     const avatarStyle = cx(styles.Avatar, size && sizeStyles[size]);
     const pixelSize = size ?? 'base';
     const dimension = sizeInPixels[pixelSize];
@@ -37,6 +38,7 @@ export const Avatar = ({ source, size, alt, title, lazy = false }: AvatarProps) 
             {lazy ? (
                 <LazyImage
                     src={source}
+                    srcSet={sourceSet}
                     height={dimension}
                     width={dimension}
                     alt={finalAlt}
@@ -46,6 +48,7 @@ export const Avatar = ({ source, size, alt, title, lazy = false }: AvatarProps) 
             ) : (
                 <img
                     src={source}
+                    srcSet={sourceSet}
                     height={dimension}
                     width={dimension}
                     alt={finalAlt}

--- a/src/components/LazyImage/LazyImage.tsx
+++ b/src/components/LazyImage/LazyImage.tsx
@@ -5,6 +5,7 @@ import cx from 'classnames';
 
 export interface LazyImageProps {
     src: string;
+    srcSet?: string;
     alt?: string;
     title?: string;
     width: number;
@@ -21,7 +22,7 @@ const getImageAttributes = (width: number, height: number, cover?: boolean) => {
     return { classNames, wrapperStyle };
 };
 
-const NativeImage = ({ src, alt, title, width, height, cover }: LazyImageProps) => {
+const NativeImage = ({ src, srcSet, alt, title, width, height, cover }: LazyImageProps) => {
     const { classNames, wrapperStyle } = getImageAttributes(width, height, cover);
 
     return (
@@ -29,18 +30,19 @@ const NativeImage = ({ src, alt, title, width, height, cover }: LazyImageProps) 
             <img
                 loading="lazy"
                 src={src}
+                srcSet={srcSet}
                 width={width}
                 height={height}
                 alt={alt}
                 title={title}
                 className={classNames}
-                role="presentation"
+                role={alt === '' ? 'presentation' : undefined}
             />
         </div>
     );
 };
 
-const FallbackImage = ({ src, alt, title, width, height, cover }: LazyImageProps) => {
+const FallbackImage = ({ src, srcSet, alt, title, width, height, cover }: LazyImageProps) => {
     const { classNames, wrapperStyle } = getImageAttributes(width, height, cover);
 
     const { ref, inView } = useInView({
@@ -54,19 +56,20 @@ const FallbackImage = ({ src, alt, title, width, height, cover }: LazyImageProps
             {inView ? (
                 <img
                     src={src}
+                    srcSet={srcSet}
                     width={width}
                     height={height}
                     alt={alt}
                     title={title}
                     className={classNames}
-                    role="presentation"
+                    role={alt === '' ? 'presentation' : undefined}
                 />
             ) : null}
         </div>
     );
 };
 
-export const LazyImage = ({ src, alt, title, width, height, cover = false }: LazyImageProps) => {
+export const LazyImage = ({ src, srcSet, alt, title, width, height, cover = false }: LazyImageProps) => {
     const supportsLazyLoading = HTMLImageElement.prototype.hasOwnProperty('loading');
     const finalAlt = alt ?? title;
 
@@ -75,9 +78,25 @@ export const LazyImage = ({ src, alt, title, width, height, cover = false }: Laz
     return (
         <>
             {supportsLazyLoading ? (
-                <NativeImage src={src} alt={finalAlt} title={title} height={height} width={width} cover={cover} />
+                <NativeImage
+                    src={src}
+                    srcSet={srcSet}
+                    alt={finalAlt}
+                    title={title}
+                    height={height}
+                    width={width}
+                    cover={cover}
+                />
             ) : (
-                <FallbackImage src={src} alt={finalAlt} title={title} height={height} width={width} cover={cover} />
+                <FallbackImage
+                    src={src}
+                    srcSet={srcSet}
+                    alt={finalAlt}
+                    title={title}
+                    height={height}
+                    width={width}
+                    cover={cover}
+                />
             )}
         </>
     );

--- a/src/components/Logo/Logo.tsx
+++ b/src/components/Logo/Logo.tsx
@@ -9,6 +9,7 @@ type pixelSize = size | 'base';
 
 export interface LogoProps {
     source: string;
+    sourceSet?: string;
     size?: size;
     alt?: string;
     title?: string;
@@ -26,7 +27,7 @@ const sizeInPixels: { [key in pixelSize]: number } = {
     large: 60
 };
 
-export const Logo = ({ source, size, alt, title, lazy = false }: LogoProps) => {
+export const Logo = ({ source, sourceSet, size, alt, title, lazy = false }: LogoProps) => {
     const logoStyle = cx(styles.Logo, size && sizeStyles[size]);
     const pixelSize = size ?? 'base';
     const dimension = sizeInPixels[pixelSize];
@@ -37,6 +38,7 @@ export const Logo = ({ source, size, alt, title, lazy = false }: LogoProps) => {
             {lazy ? (
                 <LazyImage
                     src={source}
+                    srcSet={sourceSet}
                     height={dimension}
                     width={dimension}
                     alt={finalAlt}
@@ -46,6 +48,7 @@ export const Logo = ({ source, size, alt, title, lazy = false }: LogoProps) => {
             ) : (
                 <img
                     src={source}
+                    srcSet={sourceSet}
                     height={dimension}
                     width={dimension}
                     alt={finalAlt}


### PR DESCRIPTION
This PR introduces support for `srcSet` configurations on both LazyImage and Logo. It also fixes an invalid aria role on LazyImage. Lastly, .gitignore was updated to ignore IntelliJ (webstorm) project files during development.

Asana Link: https://app.asana.com/0/174985629888208/1205960258821029/f

There's a branch up on QA-8 built with a locally packed version of Playbook, featuring these updates.