### PR TITLE
Chore: make modal titles larger

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,6 +6,8 @@ See [the versioning guidelines](VERSIONING.md) for how to format entries.
 
 ### Enhancements
 
+-- Bump up the font size of `Modal` titles to 24px ([#123](https://github.com/FieldLevel/FieldLevelPlaybook/pull/123))
+
 ### Bug fixes
 
 ### Documentation

--- a/src/components/Modal/Modal.module.css
+++ b/src/components/Modal/Modal.module.css
@@ -30,7 +30,9 @@
 }
 
 .Header {
-    @apply p-4 pb-0;
+    @apply p-4 pr-8 pb-0 m-0 font-bold text-base;
+    font-size: 1.5rem; /* 24px */
+    line-height: 1.75rem; /* 28px */
 }
 
 .Body {

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import cx from 'classnames';
 import { DialogOverlay, DialogContent } from '@reach/dialog';
 
-import { Heading } from '../Heading';
 import { Button } from '../Button';
 import { ButtonGroup } from '../ButtonGroup';
 import { Icon } from '../Icon';
@@ -15,7 +14,7 @@ import styles from './Modal.module.css';
 const Header = ({ id, title }: { id: string; title: string }) => {
     return (
         <div id={id} className={styles.Header}>
-            <Heading>{title}</Heading>
+            {title}
         </div>
     );
 };


### PR DESCRIPTION
This PR bumps up the font size on `Modal` to 24px

https://app.asana.com/0/0/1206513433904250/f