### PR TITLE
Fix: set font size to text-body-lg on mobile for TextInput/Select

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,6 +6,7 @@ See [the versioning guidelines](VERSIONING.md) for how to format entries.
 
 ### Enhancements
 
+-   Set font size to `text-body-lg` on mobile for `TextInput` and `Select` components ([#124](https://github.com/FieldLevel/FieldLevelPlaybook/pull/124))
 -   Bump up the font size of `Modal` titles to 24px ([#123](https://github.com/FieldLevel/FieldLevelPlaybook/pull/123))
 -   Add animation to `Feedback` component ([#122](https://github.com/FieldLevel/FieldLevelPlaybook/pull/122))
 -   Creates a new color definition for placeholder text ([#121](https://github.com/FieldLevel/FieldLevelPlaybook/pull/121))

--- a/src/components/Select/Select.module.css
+++ b/src/components/Select/Select.module.css
@@ -3,7 +3,7 @@
 }
 
 .Select select {
-    @apply rounded-md shadow-sm border bg-secondary-base border-base py-2 px-3 w-full appearance-none;
+    @apply rounded-md shadow-sm border bg-secondary-base border-base py-2 px-3 w-full appearance-none text-body-lg md:text-body; 
     @apply outline-none focus:ring placeholder-base;
 }
 

--- a/src/components/TextInput/TextInput.module.css
+++ b/src/components/TextInput/TextInput.module.css
@@ -4,7 +4,7 @@
 
 .TextInput input,
 .TextInput textarea {
-    @apply rounded-md shadow-sm border border-base py-2 px-3 w-full align-bottom resize-none;
+    @apply rounded-md shadow-sm border border-base py-2 px-3 w-full align-bottom resize-none text-body-lg md:text-body;
     @apply outline-none focus:ring placeholder-base;
     line-height: 20px;
     min-height: 40px;


### PR DESCRIPTION
This PR changes the font size to 16px for `Select` and `TextInput` components to avoid the iOS zoom issue.

https://app.asana.com/0/0/1206490214344426/f