### PR TITLE
Feature: add min/max/step props to TextInput

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,6 +6,8 @@ See [the versioning guidelines](VERSIONING.md) for how to format entries.
 
 ### Enhancements
 
+-   Add `min`, `max`, and `step` props to `TextInput` component ([128](https://github.com/FieldLevel/FieldLevelPlaybook/pull/128))
+
 ### Bug fixes
 
 ### Documentation

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -38,6 +38,9 @@ export interface TextInputProps {
     label?: string;
     action?: Action;
     value?: string;
+    min?: number;
+    max?: number;
+    step?: number | 'any';
     placeholder?: string;
     rows?: number;
     maxRows?: number;
@@ -56,6 +59,9 @@ export const TextInput = React.forwardRef(function TextInput(
         label,
         action,
         value,
+        min,
+        max,
+        step,
         placeholder,
         rows,
         maxRows,
@@ -168,6 +174,9 @@ export const TextInput = React.forwardRef(function TextInput(
         type: type || 'text',
         name,
         value,
+        min,
+        max,
+        step,
         placeholder,
         maxLength,
         rows: rows && (currentRows || 1),


### PR DESCRIPTION
  This PR adds `min`, `max`, and `step` props to `TextInput`.  

Resolves ([77](https://github.com/FieldLevel/FieldLevelPlaybook/issues/77))