### PR TITLE
Chore: add onOpenAutoFocus prop to Modal

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -5,6 +5,7 @@ See [the versioning guidelines](VERSIONING.md) for how to format entries.
 ### Breaking changes
 
 ### Enhancements
+- Add onOpenAutoFocus prop to Modal to support equivalent prop in Radix/Dialog.Content
 
 ### Bug fixes
 

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -46,6 +46,8 @@ export interface ModalProps {
     ariaLabel?: string;
     /** Optionally configure the aria-description of the dialog.*/
     ariaDescription?: string;
+    /** Optionally configure the "auto-focus on dialog open" behavior by passing an event handler (eg e.preventDefault()). By default, the first focusable item in the Dialog Content is focused */
+    onOpenAutoFocus?(): void;
     variant?: variant;
     primaryAction?: PrimaryAction;
     secondaryAction?: Action;
@@ -73,7 +75,8 @@ export const Modal = ({
     primaryAction,
     secondaryAction,
     tertiaryAction,
-    children
+    children,
+    onOpenAutoFocus
 }: ModalProps) => {
     const headerId = useUniqueId('ModalHeader');
     const bodyId = useUniqueId('ModalBody');
@@ -138,7 +141,7 @@ export const Modal = ({
             <Dialog.Portal>
                 <Dialog.Overlay className={styles.Overlay} />
                 <div className={containerStyles}>
-                    <Dialog.Content className={contentStyles} {...contentAriaProps}>
+                    <Dialog.Content className={contentStyles} {...contentAriaProps} onOpenAutoFocus={onOpenAutoFocus}>
                         <VisuallyHidden.Root asChild>
                             <Dialog.Title>{ariaLabel || title || 'Modal'}</Dialog.Title>
                         </VisuallyHidden.Root>


### PR DESCRIPTION
While migrating the new Recruiter Search experience, QA feedback came back requesting that we not "auto focus" any elements when the Modal dialog opens. That behavior is customizable via Radix/Dialog.Content, but we weren't supporting any way to configure that prop. This PR just opens up that possibility. 