### PR TITLE
Feature: Introduce persistent mode for Modal

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -5,14 +5,18 @@ See [the versioning guidelines](VERSIONING.md) for how to format entries.
 ### Breaking changes
 
 ### Enhancements
-- Adds support for advanced CSS configurations [(#153)](https://github.com/FieldLevel/FieldLevelPlaybook/pull/153)
+
+-   Adds support for advanced CSS configurations [(#153)](https://github.com/FieldLevel/FieldLevelPlaybook/pull/153)
+-   Adds optional `persistent` mode to `Modal` [(#154)](https://github.com/FieldLevel/FieldLevelPlaybook/pull/154)
 
 ### Bug fixes
-- Removes duplicate type emittance [(#153)](https://github.com/FieldLevel/FieldLevelPlaybook/pull/153)
+
+-   Removes duplicate type emittance [(#153)](https://github.com/FieldLevel/FieldLevelPlaybook/pull/153)
 
 ### Documentation
-- Adds documentation about implementing advanced CSS configurations [(#153)](https://github.com/FieldLevel/FieldLevelPlaybook/pull/153)
-- Adds annotation about our build process / webpack strategy [(#153)](https://github.com/FieldLevel/FieldLevelPlaybook/pull/153)
+
+-   Adds documentation about implementing advanced CSS configurations [(#153)](https://github.com/FieldLevel/FieldLevelPlaybook/pull/153)
+-   Adds annotation about our build process / webpack strategy [(#153)](https://github.com/FieldLevel/FieldLevelPlaybook/pull/153)
 
 ### Development workflow
 

--- a/docs/Overlays/Modal.mdx
+++ b/docs/Overlays/Modal.mdx
@@ -59,3 +59,10 @@ Use a small modal when less horizontal space makes the content more readable.
 Use a large modal when more horizontal space makes the content more readable.
 
 <Canvas of={stories.Large} />
+
+## Persistent
+
+Use a persistent modal when you want to prevent the user from accidentally dismissing the modal with a background
+interaction and be sure to provide an explicit interaction to dismiss.
+
+<Canvas of={stories.Persistent} />

--- a/docs/Overlays/Modal.stories.tsx
+++ b/docs/Overlays/Modal.stories.tsx
@@ -257,6 +257,38 @@ const LargeExample = () => {
         </>
     );
 };
+
 export const Large: Story = {
     render: () => <LargeExample />
+};
+
+export const Persistent: Story = {
+    render: () => {
+        const [open, setOpen] = useState(false);
+        const toggleOpen = () => {
+            setOpen((prev) => !prev);
+        };
+
+        return (
+            <>
+                <Button onClick={toggleOpen}>Open</Button>
+                <Modal
+                    title="Persistent Modal"
+                    persistent
+                    open={open}
+                    onDismiss={toggleOpen}
+                    primaryAction={{ content: 'Ok', onAction: toggleOpen }}
+                >
+                    This is a persistent modal that can only be closed programmatically.
+                </Modal>
+            </>
+        );
+    },
+    parameters: {
+        docs: {
+            source: {
+                type: 'dynamic'
+            }
+        }
+    }
 };

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -49,6 +49,7 @@ export interface ModalProps {
     /** Optionally configure the "auto-focus on dialog open" behavior by passing an event handler (eg e.preventDefault()). By default, the first focusable item in the Dialog Content is focused */
     onOpenAutoFocus?(): void;
     variant?: variant;
+    persistent?: boolean;
     primaryAction?: PrimaryAction;
     secondaryAction?: Action;
     tertiaryAction?: TertiaryAction;
@@ -72,6 +73,7 @@ export const Modal = ({
     ariaLabel,
     ariaDescription,
     variant,
+    persistent = false,
     primaryAction,
     secondaryAction,
     tertiaryAction,
@@ -147,6 +149,14 @@ export const Modal = ({
                         className={contentStyles}
                         {...contentAriaProps}
                         onOpenAutoFocus={onOpenAutoFocus ?? defaultOnOpenAutoFocus}
+                        onEscapeKeyDown={(e: Event) => {
+                            if (!persistent) return;
+                            e.preventDefault();
+                        }}
+                        onInteractOutside={(e: Event) => {
+                            if (!persistent) return;
+                            e.preventDefault();
+                        }}
                     >
                         <VisuallyHidden.Root asChild>
                             <Dialog.Title>{ariaLabel || title || 'Modal'}</Dialog.Title>
@@ -159,7 +169,7 @@ export const Modal = ({
                         {headerContent}
                         {bodyContent}
                         {footerContent}
-                        {closeContent}
+                        {!persistent && closeContent}
                     </Dialog.Content>
                 </div>
             </Dialog.Portal>


### PR DESCRIPTION
Introduces a new prop for `Modal` called `persistent` that hides the close button and prevents user interaction outside the modal and pressing the Escape key from automatically dismissing the Modal. This prop will default to `false` so existing `Modal` usage will be unaffected.