### PR TITLE
Feature: More customization for Feedback

### DIFF
--- a/docs/Feedback/Feedback.mdx
+++ b/docs/Feedback/Feedback.mdx
@@ -14,20 +14,36 @@ Feedback enhances user interaction by delivering confirmations, warnings, and er
 
 ## With Action
 
+Use the `action` prop to include a button
+
 <Canvas of={stories.WithAction} />
 
-## With Message
-
-<Canvas of={stories.WithMessage} />
-
-## With Message and Action
-
-<Canvas of={stories.WithMessageAction} />
-
 ## Success
+
+Use the "success" `variant` to confirm some successful action.
 
 <Canvas of={stories.Success} />
 
 ## Critical
 
+Use the "critical" `variant` to display an error message after an unsucessful action.
+
 <Canvas of={stories.Critical} />
+
+## Custom
+
+Use the `customRendering` prop to provide completely custom content.
+
+<Canvas of={stories.Custom} />
+
+## Position
+
+Use the `position` prop and `offsetX`/`offsetY` props to change the animation direction and final position of the Feedback in the viewport.
+
+<Canvas of={stories.Position} />
+
+## Duration
+
+Use the `duration` prop when you want the Feedback to be visible longer or shorter than the default 5 seconds.
+
+<Canvas of={stories.Duration} />

--- a/docs/Feedback/Feedback.stories.tsx
+++ b/docs/Feedback/Feedback.stories.tsx
@@ -2,7 +2,7 @@
 import React, { useState } from 'react';
 import { StoryObj, Meta } from '@storybook/react';
 
-import { Feedback, FeedbackProps, Button } from '../../src';
+import { Feedback, FeedbackProps, Button, Avatar } from '../../src';
 
 const meta: Meta<typeof Feedback> = {
     component: Feedback,
@@ -22,7 +22,7 @@ const DefaultExample = (args: Partial<FeedbackProps>) => {
     return (
         <>
             <Button onClick={toggleShow}>Show</Button>
-            <Feedback show={show} title="Something happened!" onDismiss={toggleShow} {...args} />
+            <Feedback show={show} message="Something happened!" onDismiss={toggleShow} {...args} />
         </>
     );
 };
@@ -31,130 +31,130 @@ export const Default: Story = {
     render: (args) => <DefaultExample {...args} />
 };
 
-const WithActionExample = () => {
-    const [show, setShow] = useState(false);
-    const toggleShow = () => {
-        setShow(!show);
-    };
-
-    return (
-        <>
-            <Button onClick={toggleShow}>Show</Button>
-            <Feedback
-                show={show}
-                title="Something happened!"
-                onDismiss={toggleShow}
-                action={{
-                    label: 'Undo',
-                    onClick: () => {
-                        alert('Undid!');
-                    }
-                }}
-            />
-        </>
-    );
-};
-
 export const WithAction: Story = {
-    render: () => <WithActionExample />
-};
+    render: () => {
+        const [show, setShow] = useState(false);
+        const toggleShow = () => {
+            setShow(!show);
+        };
 
-const WithMessageExample = () => {
-    const [show, setShow] = useState(false);
-    const toggleShow = () => {
-        setShow(!show);
-    };
-
-    return (
-        <>
-            <Button onClick={toggleShow}>Show</Button>
-            <Feedback
-                show={show}
-                title="Something!"
-                message="With some more detailed message."
-                onDismiss={toggleShow}
-            />
-        </>
-    );
-};
-
-export const WithMessage: Story = {
-    render: () => <WithMessageExample />
-};
-
-const WithMessageActionExample = () => {
-    const [show, setShow] = useState(false);
-    const toggleShow = () => {
-        setShow(!show);
-    };
-
-    return (
-        <>
-            <Button onClick={toggleShow}>Show</Button>
-            <Feedback
-                show={show}
-                title="Something!"
-                message="With some more detailed message."
-                onDismiss={toggleShow}
-                action={{
-                    label: 'Undo',
-                    onClick: () => {
-                        alert('Undid!');
-                    }
-                }}
-            />
-        </>
-    );
-};
-
-export const WithMessageAction: Story = {
-    render: () => <WithMessageActionExample />
-};
-
-const SuccessExample = () => {
-    const [show, setShow] = useState(false);
-    const toggleShow = () => {
-        setShow(!show);
-    };
-
-    return (
-        <>
-            <Button onClick={toggleShow}>Show</Button>
-            <Feedback
-                show={show}
-                variant="success"
-                title="Something good!"
-                message="With some more detailed message."
-                onDismiss={toggleShow}
-            />
-        </>
-    );
+        return (
+            <>
+                <Button onClick={toggleShow}>Show</Button>
+                <Feedback
+                    show={show}
+                    message="Something happened!"
+                    onDismiss={toggleShow}
+                    action={{
+                        label: 'Undo',
+                        onClick: () => {
+                            alert('Undid it!');
+                        }
+                    }}
+                />
+            </>
+        );
+    }
 };
 
 export const Success: Story = {
-    render: () => <SuccessExample />
-};
+    render: () => {
+        const [show, setShow] = useState(false);
+        const toggleShow = () => {
+            setShow(!show);
+        };
 
-const CriticalExample = () => {
-    const [show, setShow] = useState(false);
-    const toggleShow = () => {
-        setShow(!show);
-    };
-
-    return (
-        <>
-            <Button onClick={toggleShow}>Show</Button>
-            <Feedback
-                show={show}
-                variant="critical"
-                title="Something bad!"
-                message="With some more detailed message."
-                onDismiss={toggleShow}
-            />
-        </>
-    );
+        return (
+            <>
+                <Button onClick={toggleShow}>Show</Button>
+                <Feedback show={show} variant="success" message="Something good!" onDismiss={toggleShow} />
+            </>
+        );
+    }
 };
 
 export const Critical: Story = {
-    render: () => <CriticalExample />
+    render: () => {
+        const [show, setShow] = useState(false);
+        const toggleShow = () => {
+            setShow(!show);
+        };
+
+        return (
+            <>
+                <Button onClick={toggleShow}>Show</Button>
+                <Feedback show={show} variant="critical" message="Something bad!" onDismiss={toggleShow} />
+            </>
+        );
+    }
+};
+
+export const Custom: Story = {
+    render: () => {
+        const [show, setShow] = useState(false);
+        const toggleShow = () => {
+            setShow(!show);
+        };
+
+        return (
+            <>
+                <Button onClick={toggleShow}>Show</Button>
+                <Feedback
+                    show={show}
+                    onDismiss={toggleShow}
+                    customRendering={
+                        <div className="flex items-center gap-2">
+                            <Avatar source="http://placecats.com/80/80" />
+                            <span>
+                                Some completely <span className="font-bold">custom</span> content
+                            </span>
+                        </div>
+                    }
+                />
+            </>
+        );
+    }
+};
+
+export const Position: Story = {
+    render: () => {
+        const [show, setShow] = useState(false);
+        const toggleShow = () => {
+            setShow(!show);
+        };
+
+        return (
+            <>
+                <Button onClick={toggleShow}>Show</Button>
+                <Feedback
+                    show={show}
+                    position="right"
+                    offsetX={100}
+                    onDismiss={toggleShow}
+                    message="Coming in from the right"
+                />
+            </>
+        );
+    }
+};
+
+export const Duration: Story = {
+    render: () => {
+        const [show, setShow] = useState(false);
+        const toggleShow = () => {
+            setShow(!show);
+        };
+
+        return (
+            <>
+                <Button onClick={toggleShow}>Show</Button>
+                <Feedback
+                    show={show}
+                    onDismiss={toggleShow}
+                    duration={10000}
+                    message="Should stay visible for longer"
+                />
+            </>
+        );
+    }
 };

--- a/src/components/Feedback/Feedback.module.css
+++ b/src/components/Feedback/Feedback.module.css
@@ -3,48 +3,27 @@
 }
 
 .Card {
-    @apply absolute max-w-sm w-full bg-foreground-base shadow-lg rounded-lg pointer-events-auto overflow-hidden p-4 flex items-start;
-    @apply border border-base;
+    @apply absolute max-w-sm w-full bg-foreground-base shadow-lg rounded-lg pointer-events-auto overflow-hidden p-4 border border-base;
 }
 
-.condensed {
-    @apply items-center py-2;
+.Content {
+    @apply flex items-start;
 }
 
 .Icon {
     @apply shrink-0 mr-3;
 }
 
-.Content {
-    @apply w-0 flex-1;
-}
-
-.Content button {
+.Action {
     @apply mt-2;
 }
 
-.condensed > .Content {
-    @apply flex justify-between items-center;
-}
-
-.condensed > .Content button {
-    @apply mt-0;
-}
-
-.Title {
-    @apply flex-1 font-bold;
-}
-
-.condensed .Title {
-    @apply py-2;
-}
-
 .Message {
-    @apply mt-1;
+    @apply flex-1 flex flex-col gap-2 text-body;
 }
 
 .Close {
-    @apply ml-4 shrink-0 flex;
+    @apply h-full ml-4 shrink-0 flex;
 }
 
 .Close button {

--- a/src/components/Feedback/Feedback.module.css
+++ b/src/components/Feedback/Feedback.module.css
@@ -1,16 +1,9 @@
 .Feedback {
-    @apply fixed inset-0 flex items-end justify-center px-4 py-6 pb-20 pointer-events-none animate-slide-in-up;
-    @apply lg:pr-6 lg:pt-20 lg:items-start lg:justify-end;    
-}
-
-@screen lg {
-    .Feedback {
-        @apply animate-slide-in-right;
-    }
+    @apply fixed top-0 left-0 right-0 bottom-0 w-full h-full pointer-events-none z-[9999];
 }
 
 .Card {
-    @apply max-w-sm w-full bg-foreground-base shadow-lg rounded-lg pointer-events-auto overflow-hidden p-4 flex items-start;
+    @apply absolute max-w-sm w-full bg-foreground-base shadow-lg rounded-lg pointer-events-auto overflow-hidden p-4 flex items-start;
     @apply border border-base;
 }
 

--- a/src/components/Feedback/Feedback.tsx
+++ b/src/components/Feedback/Feedback.tsx
@@ -14,12 +14,19 @@ interface Action {
     onClick?(): void;
 }
 
+type position = 'top' | 'right' | 'bottom' | 'left';
 type variant = 'success' | 'critical';
+
 export interface FeedbackProps {
     show: boolean;
     title: string;
     message?: string;
     variant?: variant;
+    position?: position;
+    offsetX?: number;
+    offsetY?: number;
+    duration?: number;
+    customRendering?: React.ReactNode;
     action?: Action;
     onDismiss?(): void;
 }
@@ -29,16 +36,60 @@ const variantIcon: { [key in variant]: JSX.Element } = {
     critical: <Icon source={ErrorMinor} color="critical" />
 };
 
-export const Feedback = ({ show, title, message, variant, action, onDismiss }: FeedbackProps) => {
+const animationStyle: { [key in position]: string } = {
+    top: 'animate-slide-in-down-centered',
+    bottom: 'animate-slide-in-up-centered',
+    right: 'animate-slide-in-right',
+    left: 'animate-slide-in-left'
+};
+
+const getPositionStyles = (position: position, offsetX: number, offsetY: number): React.CSSProperties => {
+    const styles: React.CSSProperties = {};
+
+    switch (position) {
+        case 'top':
+            styles.top = offsetY;
+            styles.left = '50%';
+            break;
+        case 'bottom':
+            styles.bottom = offsetY;
+            styles.left = '50%';
+            break;
+        case 'left':
+            styles.left = offsetX;
+            styles.top = offsetY;
+            break;
+        case 'right':
+            styles.right = offsetX;
+            styles.top = offsetY;
+    }
+
+    return styles;
+};
+
+export const Feedback = ({
+    show,
+    title,
+    message,
+    variant,
+    position = 'bottom',
+    offsetX = 0,
+    offsetY = 0,
+    duration = 5000,
+    customRendering,
+    action,
+    onDismiss
+}: FeedbackProps) => {
     const iconContent = variant && variantIcon[variant];
-    const cardStyle = cx(styles.Card, !message && styles.condensed);
+    const cardStyle = cx(styles.Card, !message && styles.condensed, animationStyle[position]);
+    const positionStyles = getPositionStyles(position, offsetX, offsetY);
 
     const dismiss = () => {
         onDismiss && onDismiss();
     };
 
-    // Dismiss after 5 seconds once shown
-    useTimeout(dismiss, 5000, show);
+    // Dismiss automatically after duration once shown
+    useTimeout(dismiss, duration, show);
 
     // Warning for title length
     if (title.length > 40) {
@@ -47,19 +98,25 @@ export const Feedback = ({ show, title, message, variant, action, onDismiss }: F
 
     const feedback = (
         <div className={styles.Feedback}>
-            <div className={cardStyle}>
-                {iconContent && <div className={styles.Icon}>{iconContent}</div>}
-                <div className={styles.Content}>
-                    <p className={styles.Title}>{title}</p>
-                    {message && <p className={styles.Message}>{message}</p>}
-                    {action && <Button>{action.label}</Button>}
-                </div>
-                <div className={styles.Close}>
-                    <button onClick={onDismiss}>
-                        <span className="sr-only">Close</span>
-                        <Icon source={CloseMajor} />
-                    </button>
-                </div>
+            <div className={cardStyle} style={positionStyles}>
+                {customRendering ? (
+                    customRendering
+                ) : (
+                    <>
+                        {iconContent && <div className={styles.Icon}>{iconContent}</div>}
+                        <div className={styles.Content}>
+                            <p className={styles.Title}>{title}</p>
+                            {message && <p className={styles.Message}>{message}</p>}
+                            {action && <Button>{action.label}</Button>}
+                        </div>
+                        <div className={styles.Close}>
+                            <button onClick={onDismiss}>
+                                <span className="sr-only">Close</span>
+                                <Icon source={CloseMajor} />
+                            </button>
+                        </div>
+                    </>
+                )}
             </div>
         </div>
     );

--- a/src/components/Feedback/Feedback.tsx
+++ b/src/components/Feedback/Feedback.tsx
@@ -3,8 +3,7 @@ import cx from 'classnames';
 
 import { Icon } from '../Icon';
 import { Button } from '../Button';
-import { CloseMajor } from '../../icons/Major';
-import { ErrorMinor, CheckCircleMinor } from '../../icons/Minor';
+import { ErrorMinor, CheckCircleMinor, CloseMinor } from '../../icons/Minor';
 import { useTimeout } from '../../utilities/use-timeout';
 
 import * as styles from './Feedback.module.css';
@@ -125,7 +124,7 @@ export const Feedback = ({
                         <span className={styles.Close}>
                             <button onClick={onDismiss}>
                                 <span className="sr-only">Close</span>
-                                <Icon source={CloseMajor} />
+                                <Icon source={CloseMinor} />
                             </button>
                         </span>
                     </div>

--- a/src/components/Feedback/Feedback.tsx
+++ b/src/components/Feedback/Feedback.tsx
@@ -19,7 +19,10 @@ type variant = 'success' | 'critical';
 
 export interface FeedbackProps {
     show: boolean;
-    title: string;
+    /**
+     * @deprecated Use message instead
+     */
+    title?: string;
     message?: string;
     variant?: variant;
     position?: position;
@@ -81,7 +84,7 @@ export const Feedback = ({
     onDismiss
 }: FeedbackProps) => {
     const iconContent = variant && variantIcon[variant];
-    const cardStyle = cx(styles.Card, !message && styles.condensed, animationStyle[position]);
+    const cardStyle = cx(styles.Card, animationStyle[position]);
     const positionStyles = getPositionStyles(position, offsetX, offsetY);
 
     const dismiss = () => {
@@ -91,9 +94,16 @@ export const Feedback = ({
     // Dismiss automatically after duration once shown
     useTimeout(dismiss, duration, show);
 
-    // Warning for title length
-    if (title.length > 40) {
-        console.error('Feedback title should be shorter than 40 characters. Add longer content in message.');
+    // Phasing out the use of title
+    // If both a title and a message are passed we are just using the message
+    // If only title is passed we are using it as the message
+    if (title && message) {
+        console.warn(
+            'Feedback :: The title prop has been deprecated. Since both title and message were passed we are only displaying the message.'
+        );
+    } else if (title) {
+        console.warn('Feedback :: The title prop has been deprecated. Use message instead.');
+        message = title;
     }
 
     const feedback = (
@@ -102,20 +112,23 @@ export const Feedback = ({
                 {customRendering ? (
                     customRendering
                 ) : (
-                    <>
+                    <div className={styles.Content}>
                         {iconContent && <div className={styles.Icon}>{iconContent}</div>}
-                        <div className={styles.Content}>
-                            <p className={styles.Title}>{title}</p>
-                            {message && <p className={styles.Message}>{message}</p>}
-                            {action && <Button>{action.label}</Button>}
-                        </div>
-                        <div className={styles.Close}>
+                        <span className={styles.Message}>
+                            {message && <p>{message}</p>}
+                            {action && (
+                                <span>
+                                    <Button size="slim">{action.label}</Button>
+                                </span>
+                            )}
+                        </span>
+                        <span className={styles.Close}>
                             <button onClick={onDismiss}>
                                 <span className="sr-only">Close</span>
                                 <Icon source={CloseMajor} />
                             </button>
-                        </div>
-                    </>
+                        </span>
+                    </div>
                 )}
             </div>
         </div>

--- a/tailwind.preset.js
+++ b/tailwind.preset.js
@@ -171,13 +171,23 @@ module.exports = {
                 slideInDown: { from: { transform: 'translate3d(0, -100%, 0)' } },
                 slideInLeft: { from: { transform: 'translate3d(-100%, 0, 0)' } },
                 slideInRight: { from: { transform: 'translate3d(100%, 0, 0)' } },
-                slideInUp: { from: { transform: 'translate3d(0, 100%, 0)' } }
+                slideInUp: { from: { transform: 'translate3d(0, 100%, 0)' } },
+                slideInDownCentered: {
+                    from: { transform: 'translate3d(-50%, -100%, 0)' },
+                    to: { transform: 'translateX(-50%)' }
+                },
+                slideInUpCentered: {
+                    from: { transform: 'translate3d(-50%, 100%, 0)' },
+                    to: { transform: 'translateX(-50%)' }
+                }
             },
             animation: {
                 'slide-in-down': 'slideInDown 0.5s forwards',
                 'slide-in-left': 'slideInLeft 0.5s forwards',
                 'slide-in-right': 'slideInRight 0.5s forwards',
-                'slide-in-up': 'slideInUp 0.3s forwards ease-out'
+                'slide-in-up': 'slideInUp 0.3s forwards ease-out',
+                'slide-in-down-centered': 'slideInDownCentered 0.5s forwards',
+                'slide-in-up-centered': 'slideInUpCentered 0.5s forwards'
             }
         }
     },


### PR DESCRIPTION
Refactors the `Feedback` component to provide more flexibility with style and positioning and simplifies the standard design by deprecating `title`. These changes were made to allow using `Feedback` in more cases including the new `SystemToast` component we use for account switching. The biggest change is that the component is no longer responsive on it's own, it expects the consuming application to handle the responsibility of setting the `position` for different screen sizes. This isn't technically a breaking change but because the component won't position as it did before without application changes and because we started deprecating the `title` prop in this version, we are treating it as a breaking change.

Changes are as follows:
- Removes responsive styling and introduces four potential `position` options (top, right, left, bottom) that control the animation and base final positioning of the component. The base position contains no offset from the edges of the viewport.
- Introduces `offsetX` and `offsetY` props that control the offset in pixels from the base final positioning provided by the `position` option. This allows us to have the component come in from the bottom and stop 20px from the bottom of the viewport, or from the right and stop 60px from the top and 16px from the right for example. Offsets are relative position.
- Deprecates the `title` prop and no longer displays a title in favor of a single `message` string. This is closer to the way we've used feedback messages historically and fixes an issue we currently have where a message without a title isn't properly aligned with the icon. Until we remove the `title` prop completely the component will throw a warning if `title` is passed and use it for the `message` and if both `title` and `message` are passed it will ignore the `title` and just use `message`.
- Introduces a `duration` prop that allows the consumer to adjust how long the feedback stays visible before automatically dismissing.
- Introduces a `customRendering` prop that ignores `message` and `variant` and renders the passed React node in it's place.
- Uses the new `CloseMinor` icon for the close button instead of `CloseMajor`.

Storybook docs have been updated to show examples of the different options.

https://app.asana.com/1/5372478215525/project/174985629888208/task/1209671313520051