### PR TITLE
Fix: onClick not set on action button in Feedback component

### DIFF
--- a/src/components/Feedback/Feedback.tsx
+++ b/src/components/Feedback/Feedback.tsx
@@ -117,7 +117,9 @@ export const Feedback = ({
                             {message && <p>{message}</p>}
                             {action && (
                                 <span>
-                                    <Button size="slim">{action.label}</Button>
+                                    <Button size="slim" onClick={action.onClick}>
+                                        {action.label}
+                                    </Button>
                                 </span>
                             )}
                         </span>


### PR DESCRIPTION
When the onClick for an action is specifed for the `Feedback` component, the onClick was not being set.

https://app.asana.com/1/5372478215525/project/174985629888208/task/1210920018225579?focus=true